### PR TITLE
Add a compile() feature to class instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,8 @@ all: $(EXE)
 $(EXE): $(OBJ); $(CXX) $(CFLAGS) $(OBJ) -o $(EXE)
 %.o: %.cpp %.h; $(CXX) $(CFLAGS) -c $< -o $@ $(DEBUG)
 
+again: clean all
+
+run: $(EXE); ./$(EXE)
+
 clean: ; rm -f $(EXE) $(OBJ)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ int main() {
   std::map<std::string, double> vars;
   vars["pi"] = 3.14;
   std::cout << calculator::calculate("-pi+1", &vars) << std::endl;
+
+  // Or if you want to evaluate an expression
+  // several times efficiently:
+  calculator c1("pi-b");
+  vars["b"] = 0.14;
+  std::cout << c1.eval(&vars) << std::endl; // 3
+  vars["b"] = 2.14;
+  std::cout << c1.eval(&vars) << std::endl; // 1
+
   return 0;
 }
 ```

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -10,6 +10,21 @@
 
 #include "shunting-yard.h"
 
+std::map<std::string, int> calculator::buildOpPrecedence() {
+  std::map<std::string, int> opPrecedence;
+
+  // Create the operator precedence map.
+  opPrecedence["("] = -1;
+  opPrecedence["<<"] = 1; opPrecedence[">>"] = 1;
+  opPrecedence["+"]  = 2; opPrecedence["-"]  = 2;
+  opPrecedence["*"]  = 3; opPrecedence["/"]  = 3; opPrecedence["%"] = 3;
+  opPrecedence["^"] = 4;
+
+  return opPrecedence;
+}
+// Builds the opPrecedence map only once:
+std::map<std::string, int> calculator::opPrecedence = calculator::buildOpPrecedence();
+
 #define isvariablechar(c) (isalpha(c) || c == '_')
 TokenQueue_t calculator::toRPN(const char* expr,
     std::map<std::string, double>* vars,
@@ -130,18 +145,11 @@ TokenQueue_t calculator::toRPN(const char* expr,
 
 double calculator::calculate(const char* expr,
     std::map<std::string, double>* vars) {
-  // 1. Create the operator precedence map.
-  std::map<std::string, int> opPrecedence;
-  opPrecedence["("] = -1;
-  opPrecedence["<<"] = 1; opPrecedence[">>"] = 1;
-  opPrecedence["+"]  = 2; opPrecedence["-"]  = 2;
-  opPrecedence["*"]  = 3; opPrecedence["/"]  = 3; opPrecedence["%"] = 3;
-  opPrecedence["^"] = 4;
 
-  // 2. Convert to RPN with Dijkstra's Shunting-yard algorithm.
-  TokenQueue_t rpn = toRPN(expr, vars, opPrecedence);
+  // 1. Convert to RPN with Dijkstra's Shunting-yard algorithm.
+  TokenQueue_t rpn = toRPN(expr, vars);
 
-  // 3. Evaluate the expression in RPN form.
+  // 2. Evaluate the expression in RPN form.
   std::stack<double> evaluation;
   while (!rpn.empty()) {
     TokenBase* base = rpn.front();

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -52,7 +52,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
       std::stringstream ss;
       ss << *expr;
       ++expr;
-      while (isvariablechar(*expr )) {
+      while( isvariablechar(*expr ) || isdigit(*expr) ) {
         ss << *expr;
         ++expr;
       }

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -32,7 +32,8 @@ public:
       std::map<std::string, double>* vars = 0);
 
 private:
-  static double calculate(TokenQueue_t RPN);
+  static double calculate(TokenQueue_t RPN,
+      std::map<std::string, double>* vars = 0);
   static void cleanRPN(TokenQueue_t& rpn);
   static TokenQueue_t toRPN(const char* expr,
       std::map<std::string, double>* vars,
@@ -49,7 +50,7 @@ public:
   void compile(const char* expr,
       std::map<std::string, double>* vars = 0,
       std::map<std::string, int> opPrecedence=opPrecedence);
-  double eval();
+  double eval(std::map<std::string, double>* vars = 0);
   std::string str();
 };
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -23,16 +23,41 @@ public:
 typedef std::queue<TokenBase*> TokenQueue_t;
 
 class calculator {
-public:
+private:
   static std::map<std::string, int> opPrecedence;
   static std::map<std::string, int> buildOpPrecedence();
+
 public:
   static double calculate(const char* expr,
       std::map<std::string, double>* vars = 0);
+
 private:
+  static double calculate(TokenQueue_t RPN);
+  static void cleanRPN(TokenQueue_t& rpn);
   static TokenQueue_t toRPN(const char* expr,
       std::map<std::string, double>* vars,
       std::map<std::string, int> opPrecedence=opPrecedence);
+
+private:
+  TokenQueue_t RPN;
+public:
+  ~calculator();
+  calculator(){}
+  calculator(const char* expr,
+      std::map<std::string, double>* vars = 0,
+      std::map<std::string, int> opPrecedence=opPrecedence);
+  void compile(const char* expr,
+      std::map<std::string, double>* vars = 0,
+      std::map<std::string, int> opPrecedence=opPrecedence);
+  double eval();
+  std::string str();
 };
 
 #endif // _SHUNTING_YARD_H
+
+
+
+
+
+
+

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -24,12 +24,15 @@ typedef std::queue<TokenBase*> TokenQueue_t;
 
 class calculator {
 public:
+  static std::map<std::string, int> opPrecedence;
+  static std::map<std::string, int> buildOpPrecedence();
+public:
   static double calculate(const char* expr,
       std::map<std::string, double>* vars = 0);
 private:
   static TokenQueue_t toRPN(const char* expr,
       std::map<std::string, double>* vars,
-      std::map<std::string, int> opPrecedence);
+      std::map<std::string, int> opPrecedence=opPrecedence);
 };
 
 #endif // _SHUNTING_YARD_H

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -5,28 +5,66 @@
 
 #include "shunting-yard.h"
 
-void assert(const char* expr, double expected, 
-    std::map<std::string, double>* vars = 0) {
-  double actual = calculator::calculate(expr, vars);
+void assert(double actual, double expected, const char* expr = 0) {
   double diff = actual - expected;
   if (diff < 0) diff *= -1;
   if (diff < 1e-15) {
-    std::cout << "'" << expr << "' indeed evaluated to " <<
-      expected << "." << std::endl;
+    if(expr) {
+      std::cout << "  '" << expr << "' indeed evaluated to " <<
+        expected << "." << std::endl;
+    } else {
+      std::cout << "  actual value '" << actual <<
+        "' indeed matches the expected value '" << expected << "'" << std::endl;
+    }
   } else {
-    std::cout << "FAILURE '" << expr << "' evaluated to " <<
-      actual << " and NOT " << expected << "!" << std::endl;
+    if(expr) {
+      std::cout << "  FAILURE '" << expr << "' evaluated to " <<
+        actual << " and NOT " << expected << "!" << std::endl;
+    } else {
+      std::cout << "  FAILURE, actual value '" << actual <<
+        "' does not match the expected value '" << expected <<
+        "'" << std::endl;
+    }
   }
+}
+void assert(const char* expr, double expected, 
+    std::map<std::string, double>* vars = 0) {
+  double actual = calculator::calculate(expr, vars);
+  assert(actual, expected, expr);
 }
 
 int main(int argc, char** argv) {
   std::map<std::string, double> vars;
   vars["pi"] = 3.14;
+
+  std::cout << "\nTests with static calculate::calculate()\n" << std::endl;
+
   assert("-pi+1", -2.14, &vars);
 
   assert("(20+10)*3/2-3", 42.0);
   assert("1 << 4", 16.0);
   assert("1+(-2*3)", -5);
 
+  std::cout << "\nTest with calculate::compile() & calculate::eval()\n" << std::endl;
+
+  calculator c1;
+  c1.compile("-pi+1", &vars);
+  assert(c1.eval(), -2.14);
+
+  calculator c2("pi+4", &vars);
+  assert(c2.eval(), 7.14);
+  assert(c2.eval(), 7.14);
+  
+  std::cout << "\nEnd testing" << std::endl;
+
   return 0;
 }
+
+
+
+
+
+
+
+
+

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
   assert("1 << 4", 16.0);
   assert("1+(-2*3)", -5);
 
-  std::cout << "\nTest with calculate::compile() & calculate::eval()\n" << std::endl;
+  std::cout << "\nTests with calculate::compile() & calculate::eval()\n" << std::endl;
 
   calculator c1;
   c1.compile("-pi+1", &vars);
@@ -54,7 +54,30 @@ int main(int argc, char** argv) {
   calculator c2("pi+4", &vars);
   assert(c2.eval(), 7.14);
   assert(c2.eval(), 7.14);
-  
+
+  calculator c3("pi+b", &vars);
+
+  vars["b"] = 0;
+  assert(c3.eval(&vars), 3.14);
+
+  vars["b"] = 4-3.14;
+  assert(c3.eval(&vars), 4);
+
+  std::cout << "\nTesting exception management\n" << std::endl;
+
+  try {
+    assert(c3.eval(), 4);
+  } catch(std::domain_error err) {
+    std::cout << "  THROWS as expected" << std::endl;
+  }
+
+  try {
+    vars.erase("b");
+    assert(c3.eval(&vars), 4);
+  } catch(std::domain_error err) {
+    std::cout << "  THROWS as expected" << std::endl;
+  }
+
   std::cout << "\nEnd testing" << std::endl;
 
   return 0;

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -36,10 +36,12 @@ void assert(const char* expr, double expected,
 int main(int argc, char** argv) {
   std::map<std::string, double> vars;
   vars["pi"] = 3.14;
+  vars["b1"] = 0;
 
   std::cout << "\nTests with static calculate::calculate()\n" << std::endl;
 
   assert("-pi+1", -2.14, &vars);
+  assert("-pi+1 + b1", -2.14, &vars);
 
   assert("(20+10)*3/2-3", 42.0);
   assert("1 << 4", 16.0);
@@ -55,27 +57,36 @@ int main(int argc, char** argv) {
   assert(c2.eval(), 7.14);
   assert(c2.eval(), 7.14);
 
-  calculator c3("pi+b", &vars);
+  calculator c3("pi+b1+b2", &vars);
 
-  vars["b"] = 0;
-  assert(c3.eval(&vars), 3.14);
+  vars["b2"] = 1;
+  assert(c3.eval(&vars), 4.14);
 
-  vars["b"] = 4-3.14;
+  vars["b2"] = .86;
   assert(c3.eval(&vars), 4);
 
   std::cout << "\nTesting exception management\n" << std::endl;
 
   try {
-    assert(c3.eval(), 4);
+    c3.eval();
   } catch(std::domain_error err) {
     std::cout << "  THROWS as expected" << std::endl;
   }
 
   try {
-    vars.erase("b");
-    assert(c3.eval(&vars), 4);
+    vars.erase("b2");
+    c3.eval(&vars);
   } catch(std::domain_error err) {
     std::cout << "  THROWS as expected" << std::endl;
+  }
+
+  try {
+    vars.erase("b1");
+    vars["b2"] = 0;
+    c3.eval(&vars);
+    std::cout << "  Do not THROW as expected" << std::endl;
+  } catch(std::domain_error err) {
+    std::cout << "  If it THROWS it's a problem!" << std::endl;
   }
 
   std::cout << "\nEnd testing" << std::endl;


### PR DESCRIPTION
Now it is possible to compile an expression to RPN once,
and then evaluate it several times with different sets of variables.

This is possible using the new class constructor and/or the compile() function.

This is useful if you want to evaluate an expression several times in different contexts, e.g.:

```c++
  std::map<std::string, double> vars;
  vars["pi"] = 3.14;
  calculator c1("pi-b");
  vars["b"] = 0.14;
  std::cout << c1.eval(&vars) << std::endl; // 3
  vars["b"] = 2.14;
  std::cout << c1.eval(&vars) << std::endl; // 1
```

None of the old functionality has changed. Everything still works as expected.

I have also added some unrelated stuff:
- A new str() function, it is helpful to debug.
- Added a new case to Makefile so you can call "make run", which builds and executes the tests.
- Some new tests to `test-shunting-yard.cpp`.
- A new example to the README.md file demonstrating this new functionality.

I hope you like it.
