### PR TITLE
Replace dynamic_cast for static_cast for speed

### DIFF
--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -10,13 +10,16 @@
 #include <string>
 #include <queue>
 
-struct TokenBase { 
+enum tokType { NONE, OP, VAR, NUM };
+
+struct TokenBase {
+  tokType type;
   virtual ~TokenBase() {}
 };
 
 template<class T> class Token : public TokenBase {
 public:
-  Token (T t) : val(t) {}
+  Token (T t, tokType type) : val(t) { this->type=type; }
   T val;
 };
 
@@ -55,10 +58,3 @@ public:
 };
 
 #endif // _SHUNTING_YARD_H
-
-
-
-
-
-
-


### PR DESCRIPTION
I changed the TokenBase and Token a little bit so we can keep track of the type of the Token. This way we can use static_cast instead dynamic_cast, which should be more efficient.