### PR TITLE
Add multi-type support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-g -Wall -pedantic #-DDEBUG
 all: $(EXE)
 
 $(EXE): $(OBJ); $(CXX) $(CFLAGS) $(OBJ) -o $(EXE)
-%.o: %.cpp %.h; $(CXX) $(CFLAGS) -c $< -o $@ $(DEBUG)
+%.o: %.cpp *.h; $(CXX) $(CFLAGS) -c $< -o $@ $(DEBUG)
 
 again: clean all
 

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -45,9 +45,6 @@ TokenQueue_t calculator::toRPN(const char* expr,
       // If the token is a number, add it to the output queue.
       char* nextChar = 0;
       double digit = strtod(expr , &nextChar);
-#     ifdef DEBUG
-        std::cout << digit << std::endl;
-#     endif
       rpnQueue.push(new Token<double>(digit, NUM));
       expr = nextChar;
       lastTokenWasOp = false;
@@ -78,15 +75,9 @@ TokenQueue_t calculator::toRPN(const char* expr,
 
       if (found) {
         // Save the token
-  #     ifdef DEBUG
-          std::cout << val << std::endl;
-  #     endif
         rpnQueue.push(val);
       } else {
         // Save the variable name:
-  #     ifdef DEBUG
-          std::cout << key << std::endl;
-  #     endif
         rpnQueue.push(new Token<std::string>(key, VAR));
       }
 
@@ -128,9 +119,6 @@ TokenQueue_t calculator::toRPN(const char* expr,
             ss.clear();
             std::string str;
             ss >> str;
-#           ifdef DEBUG
-              std::cout << str << std::endl;
-#           endif
 
             if (lastTokenWasOp) {
               // Convert unary operators to binary in the RPN.

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -10,8 +10,8 @@
 
 #include "shunting-yard.h"
 
-std::map<std::string, int> calculator::buildOpPrecedence() {
-  std::map<std::string, int> opp;
+OppMap_t calculator::buildOpPrecedence() {
+  OppMap_t opp;
 
   // Create the operator precedence map based on C++ default
   // precedence order as described on cppreference website:
@@ -29,12 +29,11 @@ std::map<std::string, int> calculator::buildOpPrecedence() {
   return opp;
 }
 // Builds the opPrecedence map only once:
-std::map<std::string, int> calculator::opPrecedence = calculator::buildOpPrecedence();
+OppMap_t calculator::opPrecedence = calculator::buildOpPrecedence();
 
 #define isvariablechar(c) (isalpha(c) || c == '_')
 TokenQueue_t calculator::toRPN(const char* expr,
-    TokenMap_t* vars,
-    std::map<std::string, int> opPrecedence) {
+    TokenMap_t* vars, OppMap_t opPrecedence) {
   TokenQueue_t rpnQueue; std::stack<std::string> operatorStack;
   bool lastTokenWasOp = true;
 
@@ -288,14 +287,12 @@ calculator::~calculator() {
 }
 
 calculator::calculator(const char* expr,
-    TokenMap_t* vars,
-    std::map<std::string, int> opPrecedence) {
+    TokenMap_t* vars, OppMap_t opPrecedence) {
   compile(expr, vars, opPrecedence);
 }
 
 void calculator::compile(const char* expr,
-    TokenMap_t* vars,
-    std::map<std::string, int> opPrecedence) {
+    TokenMap_t* vars, OppMap_t opPrecedence) {
 
   // Make sure it is empty:
   cleanRPN(this->RPN);

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -149,20 +149,20 @@ TokenQueue_t calculator::toRPN(const char* expr,
   return rpnQueue;
 }
 
-double calculator::calculate(const char* expr,
+TokenBase* calculator::calculate(const char* expr,
     TokenMap_t* vars) {
 
   // Convert to RPN with Dijkstra's Shunting-yard algorithm.
   TokenQueue_t rpn = toRPN(expr, vars);
 
-  double ret = calculate(rpn);
+  TokenBase* ret = calculate(rpn);
 
   cleanRPN(rpn);
 
   return ret;
 }
 
-double calculator::calculate(TokenQueue_t _rpn,
+TokenBase* calculator::calculate(TokenQueue_t _rpn,
     TokenMap_t* vars) {
 
   TokenQueue_t rpn;
@@ -252,13 +252,8 @@ double calculator::calculate(TokenQueue_t _rpn,
       evaluation.push(base);
     }
   }
-  TokenBase* top = evaluation.top();
-  evaluation.pop();
 
-  double result = static_cast<Token<double>*>(top)->val;
-  delete top;
-
-  return result;
+  return evaluation.top();
 }
 
 void calculator::cleanRPN(TokenQueue_t& rpn) {
@@ -288,7 +283,7 @@ void calculator::compile(const char* expr,
   this->RPN = calculator::toRPN(expr, vars, opPrecedence);
 }
 
-double calculator::eval(TokenMap_t* vars) {
+TokenBase* calculator::eval(TokenMap_t* vars) {
   return calculate(this->RPN, vars);
 }
 

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -33,7 +33,7 @@ std::map<std::string, int> calculator::opPrecedence = calculator::buildOpPrecede
 
 #define isvariablechar(c) (isalpha(c) || c == '_')
 TokenQueue_t calculator::toRPN(const char* expr,
-    std::map<std::string, double>* vars,
+    TokenMap_t* vars,
     std::map<std::string, int> opPrecedence) {
   TokenQueue_t rpnQueue; std::stack<std::string> operatorStack;
   bool lastTokenWasOp = true;
@@ -73,7 +73,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
       } else if(key == "false") {
         found = true; val = 0;
       } else if(vars) {
-        std::map<std::string, double>::iterator it = vars->find(key);
+        TokenMap_t::iterator it = vars->find(key);
         if(it != vars->end()) { found = true; val = it->second; }
       }
 
@@ -163,7 +163,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
 }
 
 double calculator::calculate(const char* expr,
-    std::map<std::string, double>* vars) {
+    TokenMap_t* vars) {
 
   // Convert to RPN with Dijkstra's Shunting-yard algorithm.
   TokenQueue_t rpn = toRPN(expr, vars);
@@ -176,7 +176,7 @@ double calculator::calculate(const char* expr,
 }
 
 double calculator::calculate(TokenQueue_t _rpn,
-    std::map<std::string, double>* vars) {
+    TokenMap_t* vars) {
 
   TokenQueue_t rpn;
 
@@ -254,7 +254,7 @@ double calculator::calculate(TokenQueue_t _rpn,
       std::string key = static_cast<Token<std::string>*>(base)->val;
       delete base;
 
-      std::map<std::string, double>::iterator it = vars->find(key);
+      TokenMap_t::iterator it = vars->find(key);
 
       if (it == vars->end()) {
         throw std::domain_error(
@@ -267,7 +267,7 @@ double calculator::calculate(TokenQueue_t _rpn,
   }
   TokenBase* top = evaluation.top();
   evaluation.pop();
-  
+
   double result = static_cast<Token<double>*>(top)->val;
   delete top;
 
@@ -288,13 +288,13 @@ calculator::~calculator() {
 }
 
 calculator::calculator(const char* expr,
-    std::map<std::string, double>* vars,
+    TokenMap_t* vars,
     std::map<std::string, int> opPrecedence) {
   compile(expr, vars, opPrecedence);
 }
 
 void calculator::compile(const char* expr,
-    std::map<std::string, double>* vars,
+    TokenMap_t* vars,
     std::map<std::string, int> opPrecedence) {
 
   // Make sure it is empty:
@@ -303,7 +303,7 @@ void calculator::compile(const char* expr,
   this->RPN = calculator::toRPN(expr, vars, opPrecedence);
 }
 
-double calculator::eval(std::map<std::string, double>* vars) {
+double calculator::eval(TokenMap_t* vars) {
   return calculate(this->RPN, vars);
 }
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -28,6 +28,7 @@ public:
 };
 
 typedef std::queue<TokenBase*> TokenQueue_t;
+typedef std::map<std::string, double> TokenMap_t;
 
 class calculator {
 private:
@@ -35,15 +36,12 @@ private:
   static std::map<std::string, int> buildOpPrecedence();
 
 public:
-  static double calculate(const char* expr,
-      std::map<std::string, double>* vars = 0);
+  static double calculate(const char* expr, TokenMap_t* vars = 0);
 
 private:
-  static double calculate(TokenQueue_t RPN,
-      std::map<std::string, double>* vars = 0);
+  static double calculate(TokenQueue_t RPN, TokenMap_t* vars = 0);
   static void cleanRPN(TokenQueue_t& rpn);
-  static TokenQueue_t toRPN(const char* expr,
-      std::map<std::string, double>* vars,
+  static TokenQueue_t toRPN(const char* expr, TokenMap_t* vars,
       std::map<std::string, int> opPrecedence=opPrecedence);
 
 private:
@@ -52,12 +50,12 @@ public:
   ~calculator();
   calculator(){}
   calculator(const char* expr,
-      std::map<std::string, double>* vars = 0,
+      TokenMap_t* vars = 0,
       std::map<std::string, int> opPrecedence=opPrecedence);
   void compile(const char* expr,
-      std::map<std::string, double>* vars = 0,
+      TokenMap_t* vars = 0,
       std::map<std::string, int> opPrecedence=opPrecedence);
-  double eval(std::map<std::string, double>* vars = 0);
+  double eval(TokenMap_t* vars = 0);
   std::string str();
 };
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -28,7 +28,7 @@ public:
 };
 
 typedef std::queue<TokenBase*> TokenQueue_t;
-typedef std::map<std::string, double> TokenMap_t;
+typedef std::map<std::string, TokenBase*> TokenMap_t;
 typedef std::map<std::string, int> OppMap_t;
 
 class calculator {

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -37,10 +37,10 @@ private:
   static OppMap_t buildOpPrecedence();
 
 public:
-  static double calculate(const char* expr, TokenMap_t* vars = 0);
+  static TokenBase* calculate(const char* expr, TokenMap_t* vars = 0);
 
 private:
-  static double calculate(TokenQueue_t RPN, TokenMap_t* vars = 0);
+  static TokenBase* calculate(TokenQueue_t RPN, TokenMap_t* vars = 0);
   static void cleanRPN(TokenQueue_t& rpn);
   static TokenQueue_t toRPN(const char* expr,
       TokenMap_t* vars,
@@ -57,7 +57,7 @@ public:
   void compile(const char* expr,
       TokenMap_t* vars = 0,
       OppMap_t opPrecedence=opPrecedence);
-  double eval(TokenMap_t* vars = 0);
+  TokenBase* eval(TokenMap_t* vars = 0);
   std::string str();
 };
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -15,12 +15,16 @@ enum tokType { NONE, OP, VAR, NUM };
 struct TokenBase {
   tokType type;
   virtual ~TokenBase() {}
+  virtual TokenBase* clone() const = 0;
 };
 
 template<class T> class Token : public TokenBase {
 public:
-  Token (T t, tokType type) : val(t) { this->type=type; }
   T val;
+  Token (T t, tokType type) : val(t) { this->type=type; }
+  virtual TokenBase* clone() const {
+    return new Token(static_cast<const Token&>(*this));
+  }
 };
 
 typedef std::queue<TokenBase*> TokenQueue_t;

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -29,11 +29,12 @@ public:
 
 typedef std::queue<TokenBase*> TokenQueue_t;
 typedef std::map<std::string, double> TokenMap_t;
+typedef std::map<std::string, int> OppMap_t;
 
 class calculator {
 private:
-  static std::map<std::string, int> opPrecedence;
-  static std::map<std::string, int> buildOpPrecedence();
+  static OppMap_t opPrecedence;
+  static OppMap_t buildOpPrecedence();
 
 public:
   static double calculate(const char* expr, TokenMap_t* vars = 0);
@@ -41,8 +42,9 @@ public:
 private:
   static double calculate(TokenQueue_t RPN, TokenMap_t* vars = 0);
   static void cleanRPN(TokenQueue_t& rpn);
-  static TokenQueue_t toRPN(const char* expr, TokenMap_t* vars,
-      std::map<std::string, int> opPrecedence=opPrecedence);
+  static TokenQueue_t toRPN(const char* expr,
+      TokenMap_t* vars,
+      OppMap_t opPrecedence=opPrecedence);
 
 private:
   TokenQueue_t RPN;
@@ -51,10 +53,10 @@ public:
   calculator(){}
   calculator(const char* expr,
       TokenMap_t* vars = 0,
-      std::map<std::string, int> opPrecedence=opPrecedence);
+      OppMap_t opPrecedence=opPrecedence);
   void compile(const char* expr,
       TokenMap_t* vars = 0,
-      std::map<std::string, int> opPrecedence=opPrecedence);
+      OppMap_t opPrecedence=opPrecedence);
   double eval(TokenMap_t* vars = 0);
   std::string str();
 };

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -50,8 +50,8 @@ void assert(const char* expr, double expected,
 
 int main(int argc, char** argv) {
   TokenMap_t vars;
-  vars["pi"] = 3.14;
-  vars["b1"] = 0;
+  vars["pi"] = new Token<double>(3.14, NUM);
+  vars["b1"] = new Token<double>(0, NUM);
 
   std::cout << "\nTests with static calculate::calculate()\n" << std::endl;
 
@@ -74,10 +74,10 @@ int main(int argc, char** argv) {
 
   calculator c3("pi+b1+b2", &vars);
 
-  vars["b2"] = 1;
+  vars["b2"] = new Token<double>(1, NUM);
   assert(c3.eval(&vars), 4.14);
 
-  vars["b2"] = .86;
+  vars["b2"] = new Token<double>(.86, NUM);
   assert(c3.eval(&vars), 4);
 
   std::cout << "\nTesting boolean expressions\n" << std::endl;
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
   });
 
   assert_not_throw({
-    vars["b2"] = 0;
+    vars["b2"] = new Token<double>(0, NUM);
     vars.erase("b1");
     c3.eval(&vars);
   });

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -6,6 +6,15 @@
 
 #include "shunting-yard.h"
 
+double toDouble(TokenBase* base) {
+  if(base->type == NUM) {
+    return static_cast<Token<double>*>(base)->val;
+  } else {
+    throw std::domain_error(
+      "Cannot convert non numeric types to double!");
+  }
+}
+
 void assert(double actual, double expected, const char* expr = 0) {
   double diff = actual - expected;
   if (diff < 0) diff *= -1;
@@ -30,7 +39,7 @@ void assert(double actual, double expected, const char* expr = 0) {
 }
 void assert(const char* expr, double expected,
     TokenMap_t* vars = 0) {
-  double actual = calculator::calculate(expr, vars);
+  double actual = toDouble(calculator::calculate(expr, vars));
   assert(actual, expected, expr);
 }
 
@@ -66,19 +75,19 @@ int main(int argc, char** argv) {
 
   calculator c1;
   c1.compile("-pi+1", &vars);
-  assert(c1.eval(), -2.14);
+  assert(toDouble(c1.eval()), -2.14);
 
   calculator c2("pi+4", &vars);
-  assert(c2.eval(), 7.14);
-  assert(c2.eval(), 7.14);
+  assert(toDouble(c2.eval()), 7.14);
+  assert(toDouble(c2.eval()), 7.14);
 
   calculator c3("pi+b1+b2", &vars);
 
   vars["b2"] = new Token<double>(1, NUM);
-  assert(c3.eval(&vars), 4.14);
+  assert(toDouble(c3.eval(&vars)), 4.14);
 
   vars["b2"] = new Token<double>(.86, NUM);
-  assert(c3.eval(&vars), 4);
+  assert(toDouble(c3.eval(&vars)), 4);
 
   std::cout << "\nTesting boolean expressions\n" << std::endl;
 

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -34,6 +34,20 @@ void assert(const char* expr, double expected,
   assert(actual, expected, expr);
 }
 
+#define assert_throws(a) {try {\
+  a; \
+  std::cout << "  FAILURE, it did not THROW as expected" << std::endl; \
+} catch(...) { \
+  std::cout << "  THROWS as expected" << std::endl; \
+}}
+
+#define assert_not_throw(a) {try {\
+  a; \
+  std::cout << "  Do not THROW as expected" << std::endl; \
+} catch(...) { \
+  std::cout << "  FAILURE, it did THROW which was unexpected" << std::endl; \
+}}
+
 int main(int argc, char** argv) {
   std::map<std::string, double> vars;
   vars["pi"] = 3.14;
@@ -82,27 +96,18 @@ int main(int argc, char** argv) {
 
   std::cout << "\nTesting exception management\n" << std::endl;
 
-  try {
-    c3.eval();
-  } catch(std::domain_error err) {
-    std::cout << "  THROWS as expected" << std::endl;
-  }
+  assert_throws(c3.eval());
 
-  try {
+  assert_throws({
     vars.erase("b2");
     c3.eval(&vars);
-  } catch(std::domain_error err) {
-    std::cout << "  THROWS as expected" << std::endl;
-  }
+  });
 
-  try {
-    vars.erase("b1");
+  assert_not_throw({
     vars["b2"] = 0;
+    vars.erase("b1");
     c3.eval(&vars);
-    std::cout << "  Do not THROW as expected" << std::endl;
-  } catch(std::domain_error err) {
-    std::cout << "  If it THROWS it's a problem!" << std::endl;
-  }
+  });
 
   std::cout << "\nEnd testing" << std::endl;
 

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -29,7 +29,7 @@ void assert(double actual, double expected, const char* expr = 0) {
   }
 }
 void assert(const char* expr, double expected,
-    std::map<std::string, double>* vars = 0) {
+    TokenMap_t* vars = 0) {
   double actual = calculator::calculate(expr, vars);
   assert(actual, expected, expr);
 }
@@ -49,7 +49,7 @@ void assert(const char* expr, double expected,
 }}
 
 int main(int argc, char** argv) {
-  std::map<std::string, double> vars;
+  TokenMap_t vars;
   vars["pi"] = 3.14;
   vars["b1"] = 0;
 


### PR DESCRIPTION
Hello @bamos, this is a major change, now the framework is ready to support new variable types as:
- `string`
- `boolean`
- `objects`

This is now possible because the evaluation now works with `TokenBase*` all the time instead
of using doubles, and the operations now check for operand types before being applied.

I think this code is very good, its clean and easy to understand (I tried to implement it 3 times with different strategies, this one is the only one that looked nice).

Some drawbacks that I plan to fix:
The variable map now is a TokenBase* map. This means that we cannot do:

```c++
vars["b1"] = 3.14;
// nor
std::cout << calculator::calculate("1+2") << std::endl;
```

But instead we need to write:

```c++
map["b1"] = new Token<double>(3.14, NUM);
// or
std::cout << ((Token<double>*)calculator::calculate("1+2"))->val << std::endl;
```

I plan to fix it using the `facade` programming pattern, i.e. a class to wrap a TokenBase* and provide a better interface. I have done it on my other attempts and worked very well. I'll add it to this new version soon.

This pull request will need you to merge the code, if you prefer i might do the merge myself and submit a new pull request.

Regards