### PR TITLE
Add packToken as a facade for TokenBase*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXE=test-shunting-yard
-SRC=$(EXE).cpp shunting-yard.cpp
+SRC=$(EXE).cpp shunting-yard.cpp packToken.cpp
 OBJ=$(SRC:.cpp=.o)
 
 CXX=g++

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -1,0 +1,56 @@
+
+#include <sstream>
+#include <string>
+#include "shunting-yard.h"
+#include "shunting-yard-exceptions.h"
+
+packToken& packToken::operator=(int t) {
+  delete base;
+  base = new Token<double>(t, NUM);
+  return *this;
+}
+
+packToken& packToken::operator=(double t) {
+  delete base;
+  base = new Token<double>(t, NUM);
+  return *this;
+}
+
+// Used mainly for testing
+bool packToken::operator==(const packToken& token) const {
+  if(token.base->type != base->type) {
+    return false;
+  } else {
+    // Compare strings to simplify code
+    return token.str().compare(str()) == 0;
+  }
+}
+
+TokenBase* packToken::operator->() const {
+  return base;
+}
+
+double packToken::asDouble() const {
+  if(base->type != NUM) {
+    throw bad_cast(
+      "The Token is not a number!");
+  }
+  return static_cast<Token<double>*>(base)->val;
+}
+
+std::string packToken::str() const {
+  std::stringstream ss;
+  switch(base->type) {
+    case NONE:
+      return "None";
+    case OP:
+      return static_cast<Token<std::string>*>(base)->val;
+    case VAR:
+      return static_cast<Token<std::string>*>(base)->val;
+    case NUM:
+      ss << asDouble();
+      return ss.str();
+    default:
+      return "unknown_type";
+  }
+}

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -17,6 +17,16 @@ packToken& packToken::operator=(double t) {
   return *this;
 }
 
+packToken& packToken::operator=(const packToken& t) {
+  if(base) delete base;
+  if(t.base) {
+    base = t.base->clone();
+  } else {
+    base = 0;
+  }
+  return *this;
+}
+
 // Used mainly for testing
 bool packToken::operator==(const packToken& token) const {
   if(!base) {

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -1,24 +1,29 @@
 
 #include <sstream>
 #include <string>
+#include <iostream>
 #include "shunting-yard.h"
 #include "shunting-yard-exceptions.h"
 
 packToken& packToken::operator=(int t) {
-  delete base;
+  if(base) delete base;
   base = new Token<double>(t, NUM);
   return *this;
 }
 
 packToken& packToken::operator=(double t) {
-  delete base;
+  if(base) delete base;
   base = new Token<double>(t, NUM);
   return *this;
 }
 
 // Used mainly for testing
 bool packToken::operator==(const packToken& token) const {
-  if(token.base->type != base->type) {
+  if(!base) {
+    return token.base == 0;
+  } else if(!token.base) {
+    return base == 0;
+  } else if(token.base->type != base->type) {
     return false;
   } else {
     // Compare strings to simplify code
@@ -30,8 +35,12 @@ TokenBase* packToken::operator->() const {
   return base;
 }
 
+std::ostream& operator<<(std::ostream &os, const packToken& t) {
+  return os << t.str();
+}
+
 double packToken::asDouble() const {
-  if(base->type != NUM) {
+  if(base->type != NUM || !base) {
     throw bad_cast(
       "The Token is not a number!");
   }
@@ -40,6 +49,7 @@ double packToken::asDouble() const {
 
 std::string packToken::str() const {
   std::stringstream ss;
+  if(!base) return "undefined";
   switch(base->type) {
     case NONE:
       return "None";

--- a/packToken.h
+++ b/packToken.h
@@ -7,6 +7,7 @@ public:
   packToken(TokenBase* t) : base(t) {}
   packToken(const TokenBase& t) : base(t.clone()) {}
   packToken(const packToken& t) : base(t.base ? t.base->clone() : 0) {}
+  packToken& operator=(const packToken& t);
 
 public:
   template<class C>

--- a/packToken.h
+++ b/packToken.h
@@ -3,15 +3,17 @@
 class packToken {
   TokenBase* base;
 public:
-  packToken() : base(new Token<void*>(0, NONE)) {}
+  packToken() : base(0) {}
+  packToken(TokenBase* t) : base(t) {}
+  packToken(const TokenBase& t) : base(t.clone()) {}
+  packToken(const packToken& t) : base(t.base ? t.base->clone() : 0) {}
 
 public:
   template<class C>
   packToken(C c, tokType type) : base(new Token<C>(c, type)) {}
   packToken(int d) : base(new Token<double>(d, NUM)) {}
   packToken(double d) : base(new Token<double>(d, NUM)) {}
-  packToken(TokenBase* t) : base(t->clone()) {}
-  ~packToken(){ delete base; }
+  ~packToken(){ if(base) delete base; }
 
   packToken& operator=(int t);
   packToken& operator=(double t);
@@ -22,3 +24,6 @@ public:
 
   std::string str() const;
 };
+
+// To allow cout to print it:
+std::ostream& operator<<(std::ostream& os, const packToken& t);

--- a/packToken.h
+++ b/packToken.h
@@ -1,0 +1,24 @@
+
+// Encapsulate TokenBase* into a friendlier interface
+class packToken {
+  TokenBase* base;
+public:
+  packToken() : base(new Token<void*>(0, NONE)) {}
+
+public:
+  template<class C>
+  packToken(C c, tokType type) : base(new Token<C>(c, type)) {}
+  packToken(int d) : base(new Token<double>(d, NUM)) {}
+  packToken(double d) : base(new Token<double>(d, NUM)) {}
+  packToken(TokenBase* t) : base(t->clone()) {}
+  ~packToken(){ delete base; }
+
+  packToken& operator=(int t);
+  packToken& operator=(double t);
+  TokenBase* operator->() const;
+  bool operator==(const packToken& t) const;
+
+  double asDouble() const;
+
+  std::string str() const;
+};

--- a/shunting-yard-exceptions.h
+++ b/shunting-yard-exceptions.h
@@ -1,0 +1,26 @@
+
+#ifndef _SHUNTING_YARD_EXCEPTIONS_H
+#define _SHUNTING_YARD_EXCEPTIONS_H
+
+#include <stdexcept>
+
+class msg_exception : public std::exception {
+protected:
+  const std::string msg;
+public:
+  msg_exception(const std::string& msg) : msg(msg) {}
+  ~msg_exception() throw() {}
+  const char* what() const throw() {
+    return msg.c_str();
+  }
+};
+
+struct bad_cast : public msg_exception {
+  bad_cast(const std::string& msg) : msg_exception(msg) {}
+};
+
+struct syntax_error : public msg_exception {
+  syntax_error(const std::string& msg) : msg_exception(msg) {}
+};
+
+#endif

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -232,6 +232,22 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn,
           throw std::domain_error("Unknown operator: '" + str + "'.");
         }
       }
+      if(b_right->type == STR && b_left->type == STR) {
+        std::string right = static_cast<Token<std::string>*>(b_right)->val;
+        std::string left = static_cast<Token<std::string>*>(b_left)->val;
+        delete b_right;
+        delete b_left;
+
+        if (!str.compare("+")) {
+          evaluation.push(new Token<std::string>(left + right, STR));
+        } else if (!str.compare("==")) {
+          evaluation.push(new Token<double>(!left.compare(right), NUM));
+        } else if (!str.compare("!=")) {
+          evaluation.push(new Token<double>(left.compare(right), NUM));
+        } else {
+          throw std::domain_error("Unknown operator: '" + str + "'.");
+        }
+      }
     } else if (base->type == VAR) { // Variable
       if (!vars) {
         throw std::domain_error(

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -190,11 +190,11 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn,
       }
       TokenBase* b_right = evaluation.top(); evaluation.pop();
       TokenBase* b_left  = evaluation.top(); evaluation.pop();
-      if(b_right->type == NUM && b_left->type == NUM) {
-        double right = static_cast<Token<double>*>(b_right)->val;
+      if(b_left->type == NUM && b_right->type == NUM) {
         double left = static_cast<Token<double>*>(b_left)->val;
-        delete b_right;
+        double right = static_cast<Token<double>*>(b_right)->val;
         delete b_left;
+        delete b_right;
 
         if (!str.compare("+")) {
           evaluation.push(new Token<double>(left + right, NUM));
@@ -231,12 +231,11 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn,
         } else {
           throw std::domain_error("Unknown operator: '" + str + "'.");
         }
-      }
-      if(b_right->type == STR && b_left->type == STR) {
-        std::string right = static_cast<Token<std::string>*>(b_right)->val;
+      } else if(b_left->type == STR && b_right->type == STR) {
         std::string left = static_cast<Token<std::string>*>(b_left)->val;
-        delete b_right;
+        std::string right = static_cast<Token<std::string>*>(b_right)->val;
         delete b_left;
+        delete b_right;
 
         if (!str.compare("+")) {
           evaluation.push(new Token<std::string>(left + right, STR));
@@ -244,6 +243,32 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn,
           evaluation.push(new Token<double>(!left.compare(right), NUM));
         } else if (!str.compare("!=")) {
           evaluation.push(new Token<double>(left.compare(right), NUM));
+        } else {
+          throw std::domain_error("Unknown operator: '" + str + "'.");
+        }
+      } else if(b_left->type == STR && b_right->type == NUM) {
+        std::string left = static_cast<Token<std::string>*>(b_left)->val;
+        double right = static_cast<Token<double>*>(b_right)->val;
+        delete b_left;
+        delete b_right;
+
+        std::stringstream ss;
+        if (!str.compare("+")) {
+          ss << left << right;
+          evaluation.push(new Token<std::string>(ss.str(), STR));
+        } else {
+          throw std::domain_error("Unknown operator: '" + str + "'.");
+        }
+      } else if(b_left->type == NUM && b_right->type == STR) {
+        double left = static_cast<Token<double>*>(b_left)->val;
+        std::string right = static_cast<Token<std::string>*>(b_right)->val;
+        delete b_left;
+        delete b_right;
+
+        std::stringstream ss;
+        if (!str.compare("+")) {
+          ss << left << right;
+          evaluation.push(new Token<std::string>(ss.str(), STR));
         } else {
           throw std::domain_error("Unknown operator: '" + str + "'.");
         }

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -30,7 +30,7 @@ public:
 #include "packToken.h"
 
 typedef std::queue<TokenBase*> TokenQueue_t;
-typedef std::map<std::string, TokenBase*> TokenMap_t;
+typedef std::map<std::string, packToken> TokenMap_t;
 typedef std::map<std::string, int> OppMap_t;
 
 class calculator {

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -1,6 +1,6 @@
 // Source: http://www.daniweb.com/software-development/cpp/code/427500/calculator-using-shunting-yard-algorithm#
 // Author: Jesse Brown
-// Modifications: Brandon Amos
+// Modifications: Brandon Amos, Vinícius Garcia
 
 #ifndef _SHUNTING_YARD_H
 #define _SHUNTING_YARD_H

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <queue>
 
-enum tokType { NONE, OP, VAR, NUM };
+enum tokType { NONE, OP, VAR, NUM, STR };
 
 struct TokenBase {
   tokType type;

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -27,6 +27,8 @@ public:
   }
 };
 
+#include "packToken.h"
+
 typedef std::queue<TokenBase*> TokenQueue_t;
 typedef std::map<std::string, TokenBase*> TokenMap_t;
 typedef std::map<std::string, int> OppMap_t;

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -103,6 +103,15 @@ int main(int argc, char** argv) {
   assert("(3 || 0) == true", true);
   assert("(false || 0) == true", false);
 
+  std::cout << "\nTesting string expressions\n" << std::endl;
+
+  vars["str1"] = new Token<std::string>("foo", STR);
+  vars["str2"] = new Token<std::string>("bar", STR);
+  vars["str3"] = new Token<std::string>("foobar", STR);
+
+  assert("str1 + str2 == str3", true, &vars);
+  assert("str1 + str2 != str3", false, &vars);
+
   std::cout << "\nTesting exception management\n" << std::endl;
 
   assert_throws(c3.eval());

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -59,8 +59,8 @@ void assert(const char* expr, double expected,
 
 int main(int argc, char** argv) {
   TokenMap_t vars;
-  vars["pi"] = new Token<double>(3.14, NUM);
-  vars["b1"] = new Token<double>(0, NUM);
+  vars["pi"] = 3.14;
+  vars["b1"] = 0;
 
   std::cout << "\nTests with static calculate::calculate()\n" << std::endl;
 
@@ -83,10 +83,10 @@ int main(int argc, char** argv) {
 
   calculator c3("pi+b1+b2", &vars);
 
-  vars["b2"] = new Token<double>(1, NUM);
+  vars["b2"] = 1;
   assert(toDouble(c3.eval(&vars)), 4.14);
 
-  vars["b2"] = new Token<double>(.86, NUM);
+  vars["b2"] = .86;
   assert(toDouble(c3.eval(&vars)), 4);
 
   std::cout << "\nTesting boolean expressions\n" << std::endl;
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
   });
 
   assert_not_throw({
-    vars["b2"] = new Token<double>(0, NUM);
+    vars["b2"] = 0;
     vars.erase("b1");
     c3.eval(&vars);
   });

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -108,9 +108,13 @@ int main(int argc, char** argv) {
   vars["str1"] = new Token<std::string>("foo", STR);
   vars["str2"] = new Token<std::string>("bar", STR);
   vars["str3"] = new Token<std::string>("foobar", STR);
+  vars["str4"] = new Token<std::string>("foo10", STR);
+  vars["str5"] = new Token<std::string>("10bar", STR);
 
   assert("str1 + str2 == str3", true, &vars);
   assert("str1 + str2 != str3", false, &vars);
+  assert("str1 + 10 == str4", true, &vars);
+  assert("10 + str2 == str5", true, &vars);
 
   std::cout << "\nTesting exception management\n" << std::endl;
 


### PR DESCRIPTION
Now the old way of accessing variables with the `TokenMap_t` works again, e.g.:

```c++
TokenMap_t map;
map["pi"] = 3.14;
std::cout << map["pi"] << std::endl; // 3.14
```

drawbacks:
The `packToken` code is not very simple, but is short enough to be understood.

everytime a new type is added we will need to update `packToken::str()` function and add an explicit coersion function `packToken::as<NewType>()` and an implicit constructor for this new type as well.

The bright side is that I think we won't use many more types, other than: String, Boolean and Map(Dict) and maybe a List type in the future.

Next work: Add string type, string operations and string literal recognition.