### PR TITLE
Add Scope concept, and fix some bugs

### DIFF
--- a/packToken.cpp
+++ b/packToken.cpp
@@ -90,6 +90,26 @@ const packToken& packToken::operator[](const char* key) const {
   return (*static_cast<Token<TokenMap_t*>*>(base)->val)[key];
 }
 
+bool packToken::asBool() const {
+  if(!base) {
+    throw bad_cast(
+      "The Token is not a number!");
+  }
+
+  switch(base->type) {
+    case NUM:
+      return static_cast<Token<double>*>(base)->val != 0;
+    case STR:
+      return static_cast<Token<std::string>*>(base)->val != std::string();
+    case MAP:
+      return true;
+    case NONE:
+      return false;
+    default:
+      throw bad_cast("Token type can not be cast to boolean!");
+  }
+}
+
 double packToken::asDouble() const {
   if(!base || base->type != NUM) {
     throw bad_cast(

--- a/packToken.h
+++ b/packToken.h
@@ -29,7 +29,9 @@ public:
   packToken& operator[](const char* key);
   const packToken& operator[](const std::string& key) const;
   const packToken& operator[](const char* key) const;
+  operator TokenBase*() { return base; }
 
+  bool asBool() const;
   double asDouble() const;
   std::string asString() const;
   TokenMap_t* asMap() const;

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -230,8 +230,14 @@ TokenBase* calculator::calculate(const char* expr, Scope local) {
   
   // Convert to RPN with Dijkstra's Shunting-yard algorithm.
   TokenQueue_t rpn = toRPN(expr, local);
+  TokenBase* ret;
 
-  TokenBase* ret = calculate(rpn, local);
+  try {
+    ret = calculate(rpn, local);
+  } catch (std::exception e) {
+    cleanRPN(rpn);
+    throw e;
+  }
 
   cleanRPN(rpn);
   return ret;

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -227,7 +227,7 @@ TokenBase* calculator::calculate(const char* expr) {
 }
 
 TokenBase* calculator::calculate(const char* expr, Scope local) {
-  
+
   // Convert to RPN with Dijkstra's Shunting-yard algorithm.
   TokenQueue_t rpn = toRPN(expr, local);
   TokenBase* ret;
@@ -377,7 +377,7 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn, Scope scope) {
         throw std::domain_error(
             "Detected variable, but the variable map is unavailable.");
       }
-      
+
       TokenBase* value = NULL;
       std::string key = static_cast<Token<std::string>*>(base)->val;
       delete base;
@@ -409,6 +409,19 @@ void calculator::cleanRPN(TokenQueue_t& rpn) {
 
 calculator::~calculator() {
   cleanRPN(this->RPN);
+}
+
+calculator::calculator(const calculator& calc) {
+  this->scope = calc.scope;
+  TokenQueue_t _rpn = calc.RPN;
+
+  // Deep copy the token list, so everything can be
+  // safely deallocated:
+  while(!_rpn.empty()) {
+    TokenBase* base = _rpn.front();
+    _rpn.pop();
+    this->RPN.push(base->clone());
+  }
 }
 
 calculator::calculator(const char* expr,
@@ -452,6 +465,23 @@ TokenBase* calculator::eval(Scope local) {
   scope.pop(local.size());
 
   return val;
+}
+
+calculator& calculator::operator=(const calculator& calc) {
+  this->scope = calc.scope;
+
+  // Make sure the RPN is empty:
+  cleanRPN(this->RPN);
+
+  // Deep copy the token list, so everything can be
+  // safely deallocated:
+  TokenQueue_t _rpn = calc.RPN;
+  while(!_rpn.empty()) {
+    TokenBase* base = _rpn.front();
+    _rpn.pop();
+    this->RPN.push(base->clone());
+  }
+  return *this;
 }
 
 /* * * * * For Debug Only * * * * */
@@ -536,4 +566,3 @@ void Scope::clean() {
 unsigned Scope::size() {
   return scope.size();
 }
-

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -9,6 +9,7 @@
 #include <stack>
 #include <string>
 #include <queue>
+#include <list>
 
 enum tokType { NONE, OP, VAR, NUM, STR, MAP };
 
@@ -34,19 +35,37 @@ typedef std::map<std::string, int> OppMap_t;
 
 #include "packToken.h"
 
+struct Scope {
+  typedef std::list<TokenMap_t*> Scope_t;
+  Scope_t scope;
+  
+  Scope() {};
+  Scope(TokenMap_t* vars);
+
+  TokenBase* find(std::string key);
+
+  void push(TokenMap_t* vars);
+  void push(Scope vars);
+  void pop();
+  void pop(unsigned N);
+  
+  void clean();
+  unsigned size();
+};
+
 class calculator {
 private:
   static OppMap_t _opPrecedence;
   static OppMap_t buildOpPrecedence();
 
 public:
-  static TokenBase* calculate(const char* expr, TokenMap_t* vars = 0);
+  static TokenBase* calculate(const char* expr);
+  static TokenBase* calculate(const char* expr, Scope scope);
 
 private:
-  static TokenBase* calculate(TokenQueue_t RPN, TokenMap_t* vars = 0);
+  static TokenBase* calculate(TokenQueue_t RPN, Scope scope);
   static void cleanRPN(TokenQueue_t& rpn);
-  static TokenQueue_t toRPN(const char* expr,
-      TokenMap_t* vars,
+  static TokenQueue_t toRPN(const char* expr, Scope scope,
       OppMap_t opPrecedence=_opPrecedence);
 
   static void handle_unary(const std::string& str,
@@ -60,15 +79,20 @@ private:
 private:
   TokenQueue_t RPN;
 public:
+  Scope scope;
+public:
   ~calculator();
   calculator(){}
-  calculator(const char* expr,
-      TokenMap_t* vars = 0,
+  calculator(const char* expr, Scope scope,
       OppMap_t opPrecedence=_opPrecedence);
   void compile(const char* expr,
-      TokenMap_t* vars = 0,
       OppMap_t opPrecedence=_opPrecedence);
-  TokenBase* eval(TokenMap_t* vars = 0);
+  void compile(const char* expr,
+      Scope local= Scope(),
+      OppMap_t opPrecedence=_opPrecedence);
+  TokenBase* eval(Scope local= Scope());
+
+  // Serialization:
   std::string str();
 };
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -38,7 +38,7 @@ typedef std::map<std::string, int> OppMap_t;
 struct Scope {
   typedef std::list<TokenMap_t*> Scope_t;
   Scope_t scope;
-  
+
   Scope() {};
   Scope(TokenMap_t* vars);
 
@@ -48,7 +48,7 @@ struct Scope {
   void push(Scope vars);
   void pop();
   void pop(unsigned N);
-  
+
   void clean();
   unsigned size();
 };
@@ -83,6 +83,7 @@ public:
 public:
   ~calculator();
   calculator(){}
+  calculator(const calculator& calc);
   calculator(const char* expr, Scope scope= Scope(),
       OppMap_t opPrecedence=_opPrecedence);
   void compile(const char* expr,
@@ -94,6 +95,9 @@ public:
 
   // Serialization:
   std::string str();
+
+  // Operators:
+  calculator& operator=(const calculator& calc);
 };
 
 #endif // _SHUNTING_YARD_H

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -83,7 +83,7 @@ public:
 public:
   ~calculator();
   calculator(){}
-  calculator(const char* expr, Scope scope,
+  calculator(const char* expr, Scope scope= Scope(),
       OppMap_t opPrecedence=_opPrecedence);
   void compile(const char* expr,
       OppMap_t opPrecedence=_opPrecedence);

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
 
   std::cout << "\nTesting map access expressions\n" << std::endl;
 
-  
+
   TokenMap_t tmap;
   vars["map"] = new Token<TokenMap_t*>(&tmap, MAP);
   tmap["key"] = "mapped value";
@@ -134,11 +134,47 @@ int main(int argc, char** argv) {
   assert("map[\"key\"+1]", "second mapped value", &vars);
   assert("map[\"key\"+2] + 3 == 13", true, &vars);
   assert("map.key1", "second mapped value", &vars);
-  tmap["key3"]["map1"] = "inseption1";
-  tmap["key3"]["map2"] = "inseption2";
-  assert("map.key3.map1", "inseption1", &vars);
-  assert("map.key3['map2']", "inseption2", &vars);
+  tmap["key3"]["map1"] = "inception1";
+  tmap["key3"]["map2"] = "inception2";
+  assert("map.key3.map1", "inception1", &vars);
+  assert("map.key3['map2']", "inception2", &vars);
   assert_throws(calculator::calculate("map[\"no_key\"]", &vars));
+
+  std::cout << "\nTesting scope management\n" << std::endl;
+
+  // Add vars to scope:
+  c3.scope.push(&vars);
+  assert(c3.eval(), 4);
+
+  tmap["b2"] = 1;
+  c3.scope.push(&tmap);
+  assert(c3.eval(), 4.14);
+
+  Scope scope = c3.scope;
+
+  // Remove vars from scope:
+  c3.scope.pop();
+  c3.scope.pop();
+
+  // Test what happens when you try to drop more namespaces than possible:
+  assert_throws(c3.scope.pop());
+
+  // Load Saved Scope
+  c3.scope = scope;
+  assert(c3.eval(), 4.14);
+
+  // Testing with 3 namespaces:
+  TokenMap_t vmap;
+  vmap["b1"] = -1.14;
+  c3.scope.push(&vmap);
+  assert(c3.eval(), 4.14);
+
+  scope = c3.scope;
+  calculator c4("pi+b1+b2", scope);
+  assert(c4.eval(), 3.);
+  assert(calculator::calculate("pi+b1+b2", scope), 3.);
+
+  c3.scope.clean();
 
   std::cout << "\nTesting exception management\n" << std::endl;
 

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -176,6 +176,18 @@ int main(int argc, char** argv) {
 
   c3.scope.clean();
 
+  std::cout << "\nTesting resource management\n" << std::endl;
+
+  calculator C1, C2("1 + 1");
+
+  // These are likely to cause seg fault if
+  // RPN copy is not handled:
+
+  // Copy:
+  assert_not_throw(calculator C3(C2));
+  // Assignment:
+  assert_not_throw(C1 = C2);
+
   std::cout << "\nTesting exception management\n" << std::endl;
 
   assert_throws(c3.eval());


### PR DESCRIPTION
Hello @bamos, I've added a `class Scope` that contain a list of `TokenMap_t*` so that the first one would be the global scope, and the rest the local scopes. Its use is optional and the API is the same as before.

The trick is this constructor: `Scope::Scope(TokenMap_t* tmap)` that allows for implicit conversion from TokenMap_t* to Scope, so we can keep the old function calls working as they did before, but now the API expects a `Scope` class where it used to expect a `TokenMap_t*`.

I also found a bug when you do:
```
calculator c1, c2("1+1");
c1 = c2; // seg fault
calculator c3(c2); // seg fault
```
And I fixed that on the last commit.

Also, i noticed a memory leak problem, it is older than these commits, I will investigate it.