### PR TITLE
Add support for the assignment operator

### DIFF
--- a/packToken.cpp
+++ b/packToken.cpp
@@ -152,6 +152,11 @@ std::string packToken::str(TokenBase* base) {
   TokenMap_t::iterator it;
 
   if (!base) return "undefined";
+
+  if (base->type & REF) {
+    base = static_cast<Token<RefValue_t>*>(base)->val.second;
+  }
+
   switch (base->type) {
     case NONE:
       return "None";

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -4,14 +4,7 @@
 #include "./shunting-yard.h"
 #include "./shunting-yard-exceptions.h"
 
-struct None_t : public TokenBase {
-  None_t() { this->type = NONE; }
-  virtual TokenBase* clone() const {
-    return new None_t(static_cast<const None_t&>(*this));
-  }
-};
-
-const packToken packToken::None = packToken(None_t());
+const packToken packToken::None = packToken(TokenNone());
 
 packToken& packToken::operator=(int t) {
   if (base) delete base;
@@ -154,7 +147,7 @@ std::string packToken::str(TokenBase* base) {
   if (!base) return "undefined";
 
   if (base->type & REF) {
-    base = static_cast<Token<RefValue_t>*>(base)->val.second;
+    base = static_cast<Token<RefValue_t>*>(base)->val.value;
   }
 
   switch (base->type) {

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -70,8 +70,10 @@ void calculator::handle_op(const std::string& str,
     throw std::domain_error("Unknown operator: `" + str + "`!");
   }
 
-  while (!operatorStack->empty() &&
-         opPrecedence[str] >= opPrecedence[operatorStack->top()]) {
+  float cur_opp = opPrecedence[str];
+  // To force "=" to be evaluated from the right to the left:
+  if (str == "=") cur_opp -= 0.1;
+  while (!operatorStack->empty() && cur_opp >= opPrecedence[operatorStack->top()]) {
     rpnQueue->push(new Token<std::string>(operatorStack->top(), OP));
     operatorStack->pop();
   }

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -25,12 +25,28 @@ template<class T> class Token : public TokenBase {
   }
 };
 
+struct TokenNone : public TokenBase {
+  TokenNone() { this->type = NONE; }
+  virtual TokenBase* clone() const {
+    return new TokenNone(static_cast<const TokenNone&>(*this));
+  }
+};
+
 class packToken;
-typedef std::pair<std::string, TokenBase*> RefValue_t;
 typedef std::queue<TokenBase*> TokenQueue_t;
 typedef std::map<std::string, packToken> TokenMap_t;
 typedef std::map<std::string, int> OppMap_t;
 typedef std::list<TokenBase*> Tuple_t;
+
+struct RefValue_t {
+  std::string name;
+  TokenBase* value;
+  TokenMap_t* source_map;
+  RefValue_t(std::string n, TokenBase* v, TokenMap_t* m) :
+    name(n), value(v), source_map(m) {}
+  RefValue_t(std::string n, TokenBase* v) :
+    name(n), value(v), source_map(0) {}
+};
 
 #include "./packToken.h"
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -63,7 +63,7 @@ class Scope {
   Scope() : Scope(NULL) {}
 
   packToken* find(std::string key) const;
-  void asign(std::string key, TokenBase* value) const;
+  void assign(std::string key, TokenBase* value) const;
 
   void push(TokenMap_t* vars) const;
   void push(Scope vars) const;
@@ -81,7 +81,7 @@ class calculator {
   static Scope empty_scope;
 
  public:
-  static packToken calculate(const char* expr, const Scope& scope = empty_scope);
+  static packToken calculate(const char* expr, const Scope& vars = empty_scope);
 
  private:
   static packToken calculate(TokenQueue_t RPN,
@@ -91,10 +91,10 @@ class calculator {
                             const Scope* vars,
                             OppMap_t opPrecedence = _opPrecedence);
 
-  static bool handle_unary(const std::string& str,
+  static bool handle_unary(const std::string& op,
                            TokenQueue_t* rpnQueue, bool lastTokenWasOp,
                            OppMap_t opPrecedence);
-  static void handle_op(const std::string& str,
+  static void handle_op(const std::string& op,
                         TokenQueue_t* rpnQueue,
                         std::stack<std::string>* operatorStack,
                         OppMap_t opPrecedence);
@@ -106,7 +106,7 @@ class calculator {
   ~calculator();
   calculator() {}
   calculator(const calculator& calc);
-  calculator(const char* expr, const Scope& scope = empty_scope,
+  calculator(const char* expr, const Scope& vars = empty_scope,
              OppMap_t opPrecedence = _opPrecedence);
   void compile(const char* expr,
                OppMap_t opPrecedence = _opPrecedence);

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -7,10 +7,11 @@
 #include <queue>
 #include <list>
 
-enum tokType { NONE, OP, VAR, NUM, STR, MAP, FUNC, TUPLE };
+enum tokType { NONE, OP, VAR, NUM, STR, MAP, FUNC, TUPLE, REF=0x10 };
+typedef unsigned char uint8_t;
 
 struct TokenBase {
-  tokType type;
+  uint8_t type;
   virtual ~TokenBase() {}
   virtual TokenBase* clone() const = 0;
 };
@@ -18,13 +19,14 @@ struct TokenBase {
 template<class T> class Token : public TokenBase {
  public:
   T val;
-  Token(T t, tokType type) : val(t) { this->type = type; }
+  Token(T t, uint8_t type) : val(t) { this->type = type; }
   virtual TokenBase* clone() const {
     return new Token(static_cast<const Token&>(*this));
   }
 };
 
 class packToken;
+typedef std::pair<std::string, TokenBase*> RefValue_t;
 typedef std::queue<TokenBase*> TokenQueue_t;
 typedef std::map<std::string, packToken> TokenMap_t;
 typedef std::map<std::string, int> OppMap_t;

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -7,7 +7,7 @@
 #include <queue>
 #include <list>
 
-enum tokType { NONE, OP, VAR, NUM, STR, MAP, FUNC, TUPLE, REF=0x10 };
+enum tokType { NONE, OP, VAR, NUM, STR, MAP, FUNC, TUPLE, REF = 0x10 };
 typedef unsigned char uint8_t;
 
 struct TokenBase {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include <iostream>
 
 #include "./shunting-yard.h"
 
@@ -111,6 +112,20 @@ TEST_CASE("Function usage expressions") {
 
   // The test bellow will fail, TODO fix it:
   // REQUIRE_NOTHROW(calculator::calculate("print()"));
+}
+
+TEST_CASE("Asignment expressions", "[!mayfail]") {
+  calculator::calculate("asignment = 10", &vars);
+
+  // Asigning to an unexistent variable works.
+  REQUIRE(calculator::calculate("asignment", &vars).asDouble() == 10);
+
+  // But it doesn't work with an existing variable:
+  INFO("This tests an asignment to an existing variable. It is on our TODO list to fix it.");
+  REQUIRE_NOTHROW(calculator::calculate("asignment = 20", &vars));
+
+  INFO("Chained asignments don't work yet, its on the TODO list to fix it.");
+  REQUIRE_NOTHROW(calculator::calculate("asign1 = asign2 = 20", &vars));
 }
 
 TEST_CASE("Scope management") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -124,8 +124,10 @@ TEST_CASE("Assignment expressions", "[!mayfail]") {
   REQUIRE_NOTHROW(calculator::calculate("assignment = 20", &vars));
   REQUIRE(calculator::calculate("assignment", &vars).asDouble() == 20);
 
-  INFO("Chained assignments don't work yet, its on the TODO list to fix it.");
-  REQUIRE_NOTHROW(calculator::calculate("assign1 = assign2 = 20", &vars));
+  // Chain assigning should work with a right-to-left order:
+  REQUIRE_NOTHROW(calculator::calculate("a = b = 20", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("a = b = c = d = 30", &vars));
+  REQUIRE(calculator::calculate("a == b && b == c && b == d && d == 30", &vars) == true);
 }
 
 TEST_CASE("Scope management") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -1,5 +1,5 @@
-#include "catch.hpp"
 #include <iostream>
+#include "catch.hpp"
 
 #include "./shunting-yard.h"
 

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -114,18 +114,18 @@ TEST_CASE("Function usage expressions") {
   // REQUIRE_NOTHROW(calculator::calculate("print()"));
 }
 
-TEST_CASE("Asignment expressions", "[!mayfail]") {
-  calculator::calculate("asignment = 10", &vars);
+TEST_CASE("Assignment expressions", "[!mayfail]") {
+  calculator::calculate("assignment = 10", &vars);
 
-  // Asigning to an unexistent variable works.
-  REQUIRE(calculator::calculate("asignment", &vars).asDouble() == 10);
+  // Assigning to an unexistent variable works.
+  REQUIRE(calculator::calculate("assignment", &vars).asDouble() == 10);
 
-  // But it doesn't work with an existing variable:
-  INFO("This tests an asignment to an existing variable. It is on our TODO list to fix it.");
-  REQUIRE_NOTHROW(calculator::calculate("asignment = 20", &vars));
+  // Assigning to existent variables should work as well.
+  REQUIRE_NOTHROW(calculator::calculate("assignment = 20", &vars));
+  REQUIRE(calculator::calculate("assignment", &vars).asDouble() == 20);
 
-  INFO("Chained asignments don't work yet, its on the TODO list to fix it.");
-  REQUIRE_NOTHROW(calculator::calculate("asign1 = asign2 = 20", &vars));
+  INFO("Chained assignments don't work yet, its on the TODO list to fix it.");
+  REQUIRE_NOTHROW(calculator::calculate("assign1 = assign2 = 20", &vars));
 }
 
 TEST_CASE("Scope management") {


### PR DESCRIPTION
Finally we can close the issue #3.

This merge adds support for assignment of variables:

```c++
a = 10
a = b
a = c.d
```

Make the evaluation of the operator `=` to be from right-to-left so this works:

```c++
a = b = c = 10
```

And also allow assignment on Tokens of type MAP:

```c++
a.b = c['foo'] = d + 4
```

I did not figure out how to make Travis check it for me yet. But as soon as it does I'll fix it =].

Edit: just fixed it =].