### PR TITLE
Simplify containers

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -27,10 +27,10 @@ packToken Function::call(packToken _this, Function* func,
     local[name] = value;
   }
 
-  packList arglist;
+  TokenList arglist;
   // Collect any extra arguments:
   while (args->size()) {
-    arglist->list.push_back(packToken(args->pop_front()));
+    arglist.list().push_back(packToken(args->pop_front()));
   }
   local["arglist"] = arglist;
   local["this"] = _this;
@@ -42,10 +42,10 @@ packToken Function::call(packToken _this, Function* func,
 
 packToken default_print(TokenMap scope) {
   // Get the argument list:
-  packList list = scope.find("arglist")->asList();
+  TokenList list = scope.find("arglist")->asList();
 
   bool first = true;
-  for (packToken item : list->list) {
+  for (packToken item : list.list()) {
     if (first) {
       first = false;
     } else {
@@ -66,14 +66,14 @@ packToken default_print(TokenMap scope) {
 
 packToken default_sum(TokenMap scope) {
   // Get the arguments:
-  packList list = scope.find("arglist")->asList();
+  TokenList list = scope.find("arglist")->asList();
 
-  if (list->list.size() == 1 && list->list.front()->type == LIST) {
-    list = list->list.front().asList();
+  if (list.list().size() == 1 && list.list().front()->type == LIST) {
+    list = list.list().front().asList();
   }
 
   double sum = 0;
-  for (packToken num : list->list) {
+  for (packToken num : list.list()) {
     sum += num.asDouble();
   }
 
@@ -206,10 +206,11 @@ packToken string_len(TokenMap scope) {
 
 packToken default_list(TokenMap scope) {
   // Get the arguments:
-  packList list = scope.find("arglist")->asList();
+  TokenList list = scope.find("arglist")->asList();
 
-  if (list->list.size() == 1 && list->list[0]->type == TUPLE) {
-    return packToken(new Token<packList>(TokenList(list->list[0]), LIST));
+  // If the only argument is a tuple:
+  if (list.list().size() == 1 && list.list()[0]->type == TUPLE) {
+    return TokenList(list.list()[0]);
   } else {
     return list;
   }

--- a/functions.cpp
+++ b/functions.cpp
@@ -40,7 +40,6 @@ packToken Function::call(packToken _this, Function* func,
 
 /* * * * * Built-in Functions: * * * * */
 
-const char* no_args[] = {""};
 packToken default_print(packMap scope) {
   // Get the argument list:
   packList list = scope->find("arglist")->asList();
@@ -227,9 +226,15 @@ CppFunction::CppFunction(packToken (*func)(packMap), unsigned int nargs,
             : func(func) {
   this->name = name;
   // Add all strings to args list:
-  for (unsigned int i = 0; i < nargs; ++i) {
+  for (uint32_t i = 0; i < nargs; ++i) {
     this->_args.push_back(args[i]);
   }
+}
+
+// Build a function with no named args:
+CppFunction::CppFunction(packToken (*func)(packMap), std::string name)
+                         : func(func) {
+  this->name = name;
 }
 
 /* * * * * CppFunction Initializer Constructor: * * * * */
@@ -238,8 +243,8 @@ struct CppFunction::Startup {
   Startup() {
     TokenMap& global = TokenMap::default_global();
 
-    global["print"] = CppFunction(&default_print, 0, no_args, "print");
-    global["sum"] = CppFunction(&default_sum, 0, no_args, "sum");
+    global["print"] = CppFunction(&default_print, "print");
+    global["sum"] = CppFunction(&default_sum, "sum");
     global["sqrt"] = CppFunction(&default_sqrt, 1, num_arg, "sqrt");
     global["sin"] = CppFunction(&default_sin, 1, num_arg, "sin");
     global["cos"] = CppFunction(&default_cos, 1, num_arg, "cos");
@@ -253,15 +258,15 @@ struct CppFunction::Startup {
     global["extend"] = CppFunction(&default_extend, 1, value_arg, "extend");
 
     // Default constructors:
-    global["list"] = CppFunction(&default_list, 0, no_args, "list");
-    global["map"] = CppFunction(&default_map, 0, no_args, "map");
+    global["list"] = CppFunction(&default_list, "list");
+    global["map"] = CppFunction(&default_map, "map");
 
     TokenMap& base_map = TokenMap::base_map();
     base_map["instanceof"] = CppFunction(&default_instanceof, 1,
                                          value_arg, "instanceof");
 
     typeMap_t& type_map = calculator::type_attribute_map();
-    type_map[STR]["len"] = CppFunction(&string_len, 0, no_args, "len");
+    type_map[STR]["len"] = CppFunction(&string_len, "len");
   }
 } CppFunction_startup;
 

--- a/functions.cpp
+++ b/functions.cpp
@@ -32,7 +32,7 @@ packToken Function::call(packToken _this, Function* func,
   while (args->size()) {
     arglist.list().push_back(packToken(args->pop_front()));
   }
-  local["arglist"] = arglist;
+  local["args"] = arglist;
   local["this"] = _this;
 
   return func->exec(local);
@@ -42,7 +42,7 @@ packToken Function::call(packToken _this, Function* func,
 
 packToken default_print(TokenMap scope) {
   // Get the argument list:
-  TokenList list = scope.find("arglist")->asList();
+  TokenList list = scope.find("args")->asList();
 
   bool first = true;
   for (packToken item : list.list()) {
@@ -66,7 +66,7 @@ packToken default_print(TokenMap scope) {
 
 packToken default_sum(TokenMap scope) {
   // Get the arguments:
-  TokenList list = scope.find("arglist")->asList();
+  TokenList list = scope.find("args")->asList();
 
   if (list.list().size() == 1 && list.list().front()->type == LIST) {
     list = list.list().front().asList();
@@ -206,7 +206,7 @@ packToken string_len(TokenMap scope) {
 
 packToken default_list(TokenMap scope) {
   // Get the arguments:
-  TokenList list = scope.find("arglist")->asList();
+  TokenList list = scope.find("args")->asList();
 
   // If the only argument is a tuple:
   if (list.list().size() == 1 && list.list()[0]->type == TUPLE) {

--- a/functions.cpp
+++ b/functions.cpp
@@ -11,9 +11,9 @@
 
 /* * * * * class Function * * * * */
 packToken Function::call(packToken _this, Function* func,
-                         Tuple* args, packMap scope) {
+                         Tuple* args, TokenMap scope) {
   // Build the local namespace:
-  packMap local = TokenMap(scope);
+  TokenMap local = scope.getChild();
 
   // Add args to local namespace:
   for (const std::string& name : func->args()) {
@@ -24,7 +24,7 @@ packToken Function::call(packToken _this, Function* func,
       value = packToken::None;
     }
 
-    (*local)[name] = value;
+    local[name] = value;
   }
 
   packList arglist;
@@ -32,17 +32,17 @@ packToken Function::call(packToken _this, Function* func,
   while (args->size()) {
     arglist->list.push_back(packToken(args->pop_front()));
   }
-  (*local)["arglist"] = arglist;
-  (*local)["this"] = _this;
+  local["arglist"] = arglist;
+  local["this"] = _this;
 
   return func->exec(local);
 }
 
 /* * * * * Built-in Functions: * * * * */
 
-packToken default_print(packMap scope) {
+packToken default_print(TokenMap scope) {
   // Get the argument list:
-  packList list = scope->find("arglist")->asList();
+  packList list = scope.find("arglist")->asList();
 
   bool first = true;
   for (packToken item : list->list) {
@@ -64,9 +64,9 @@ packToken default_print(packMap scope) {
   return packToken::None;
 }
 
-packToken default_sum(packMap scope) {
+packToken default_sum(TokenMap scope) {
   // Get the arguments:
-  packList list = scope->find("arglist")->asList();
+  packList list = scope.find("arglist")->asList();
 
   if (list->list.size() == 1 && list->list.front()->type == LIST) {
     list = list->list.front().asList();
@@ -81,14 +81,14 @@ packToken default_sum(packMap scope) {
 }
 
 const char* value_arg[] = {"value"};
-packToken default_eval(packMap scope) {
-  std::string code = scope->find("value")->asString();
+packToken default_eval(TokenMap scope) {
+  std::string code = scope.find("value")->asString();
   // Evaluate it as a calculator expression:
   return calculator::calculate(code.c_str(), scope);
 }
 
-packToken default_float(packMap scope) {
-  packToken* tok = scope->find("value");
+packToken default_float(TokenMap scope) {
+  packToken* tok = scope.find("value");
   if ((*tok)->type == NUM) return *tok;
 
   // Convert it to double:
@@ -105,15 +105,15 @@ packToken default_float(packMap scope) {
   return ret;
 }
 
-packToken default_str(packMap scope) {
+packToken default_str(TokenMap scope) {
   // Return its string representation:
-  packToken* tok = scope->find("value");
+  packToken* tok = scope.find("value");
   if ((*tok)->type == STR) return *tok;
   return tok->str();
 }
 
-packToken default_type(packMap scope) {
-  packToken* tok = scope->find("value");
+packToken default_type(TokenMap scope) {
+  packToken* tok = scope.find("value");
   switch ((*tok)->type) {
   case NONE: return "none";
   case VAR: return "variable";
@@ -128,85 +128,85 @@ packToken default_type(packMap scope) {
   }
 }
 
-packToken default_extend(packMap scope) {
-  packToken* tok = scope->find("value");
+packToken default_extend(TokenMap scope) {
+  packToken* tok = scope.find("value");
 
   if ((*tok)->type == MAP) {
-    return packMap(TokenMap(tok->asMap()));
+    return tok->asMap().getChild();
   } else {
     throw std::runtime_error(tok->str() + " is not extensible!");
   }
 }
 
-packToken default_instanceof(packMap scope) {
-  TokenMap* _super = scope->find("value")->asMap();
-  TokenMap* _this = scope->find("this")->asMap()->parent;
+packToken default_instanceof(TokenMap scope) {
+  TokenMap _super = scope.find("value")->asMap();
+  TokenMap* _this = scope.find("this")->asMap().parent();
 
   TokenMap* parent = _this;
   while (parent) {
-    if (parent == _super) {
+    if ((*parent) == _super) {
       return true;
     }
 
-    parent = parent->parent;
+    parent = parent->parent();
   }
 
   return false;
 }
 
 const char* num_arg[] = {"number"};
-packToken default_sqrt(packMap scope) {
+packToken default_sqrt(TokenMap scope) {
   // Get a single argument:
-  double number = scope->find("number")->asDouble();
+  double number = scope.find("number")->asDouble();
 
   return sqrt(number);
 }
-packToken default_sin(packMap scope) {
+packToken default_sin(TokenMap scope) {
   // Get a single argument:
-  double number = scope->find("number")->asDouble();
+  double number = scope.find("number")->asDouble();
 
   return sin(number);
 }
-packToken default_cos(packMap scope) {
+packToken default_cos(TokenMap scope) {
   // Get a single argument:
-  double number = scope->find("number")->asDouble();
+  double number = scope.find("number")->asDouble();
 
   return cos(number);
 }
-packToken default_tan(packMap scope) {
+packToken default_tan(TokenMap scope) {
   // Get a single argument:
-  double number = scope->find("number")->asDouble();
+  double number = scope.find("number")->asDouble();
 
   return tan(number);
 }
-packToken default_abs(packMap scope) {
+packToken default_abs(TokenMap scope) {
   // Get a single argument:
-  double number = scope->find("number")->asDouble();
+  double number = scope.find("number")->asDouble();
 
   return std::abs(number);
 }
 
 const char* pow_args[] = {"number", "exp"};
-packToken default_pow(packMap scope) {
+packToken default_pow(TokenMap scope) {
   // Get two arguments:
-  double number = scope->find("number")->asDouble();
-  double exp = scope->find("exp")->asDouble();
+  double number = scope.find("number")->asDouble();
+  double exp = scope.find("exp")->asDouble();
 
   return pow(number, exp);
 }
 
 /* * * * * Type-specific default functions * * * * */
 
-packToken string_len(packMap scope) {
-  std::string str = scope->find("this")->asString();
+packToken string_len(TokenMap scope) {
+  std::string str = scope.find("this")->asString();
   return static_cast<int>(str.size());
 }
 
 /* * * * * default constructor functions * * * * */
 
-packToken default_list(packMap scope) {
+packToken default_list(TokenMap scope) {
   // Get the arguments:
-  packList list = scope->find("arglist")->asList();
+  packList list = scope.find("arglist")->asList();
 
   if (list->list.size() == 1 && list->list[0]->type == TUPLE) {
     return packToken(new Token<packList>(TokenList(list->list[0]), LIST));
@@ -215,15 +215,15 @@ packToken default_list(packMap scope) {
   }
 }
 
-packToken default_map(packMap scope) {
-  return packMap();
+packToken default_map(TokenMap scope) {
+  return TokenMap();
 }
 
 /* * * * * class CppFunction * * * * */
 
-CppFunction::CppFunction(packToken (*func)(packMap), unsigned int nargs,
-            const char** args, std::string name)
-            : func(func) {
+CppFunction::CppFunction(packToken (*func)(TokenMap), unsigned int nargs,
+                         const char** args, std::string name)
+                         : func(func) {
   this->name = name;
   // Add all strings to args list:
   for (uint32_t i = 0; i < nargs; ++i) {
@@ -232,7 +232,7 @@ CppFunction::CppFunction(packToken (*func)(packMap), unsigned int nargs,
 }
 
 // Build a function with no named args:
-CppFunction::CppFunction(packToken (*func)(packMap), std::string name)
+CppFunction::CppFunction(packToken (*func)(TokenMap), std::string name)
                          : func(func) {
   this->name = name;
 }

--- a/functions.h
+++ b/functions.h
@@ -36,6 +36,7 @@ class CppFunction : public Function {
 
   CppFunction(packToken (*func)(packMap), unsigned int nargs,
               const char** args, std::string name = "");
+  CppFunction(packToken (*func)(packMap), std::string name = "");
 
   virtual const argsList args() const { return _args; }
   virtual packToken exec(packMap scope) const { return func(scope); }

--- a/functions.h
+++ b/functions.h
@@ -7,7 +7,7 @@
 class Function : public TokenBase {
  public:
   static packToken call(packToken _this, Function* func,
-                        Tuple* args, packMap scope);
+                        Tuple* args, TokenMap scope);
 
  public:
   typedef std::list<std::string> argsList;
@@ -20,7 +20,7 @@ class Function : public TokenBase {
   virtual ~Function() {}
 
   virtual const argsList args() const = 0;
-  virtual packToken exec(packMap scope) const = 0;
+  virtual packToken exec(TokenMap scope) const = 0;
   virtual TokenBase* clone() const = 0;
 };
 
@@ -31,15 +31,15 @@ class CppFunction : public Function {
   struct Startup;
 
  public:
-  packToken (*func)(packMap);
+  packToken (*func)(TokenMap);
   argsList _args;
 
-  CppFunction(packToken (*func)(packMap), unsigned int nargs,
+  CppFunction(packToken (*func)(TokenMap), unsigned int nargs,
               const char** args, std::string name = "");
-  CppFunction(packToken (*func)(packMap), std::string name = "");
+  CppFunction(packToken (*func)(TokenMap), std::string name = "");
 
   virtual const argsList args() const { return _args; }
-  virtual packToken exec(packMap scope) const { return func(scope); }
+  virtual packToken exec(TokenMap scope) const { return func(scope); }
 
   virtual TokenBase* clone() const {
     return new CppFunction(static_cast<const CppFunction&>(*this));

--- a/objects.cpp
+++ b/objects.cpp
@@ -58,7 +58,6 @@ packToken list_pop(packMap scope) {
   return result;
 }
 
-const char* list_no_args[] = {""};
 packToken list_len(packMap scope) {
   packList list = scope->find("this")->asList();
   return list->list.size();
@@ -71,7 +70,7 @@ struct TokenList::Startup {
     TokenMap& base = calculator::type_attribute_map()[LIST];
     base["push"] = CppFunction(list_push, 1, push_args, "push");
     base["pop"] = CppFunction(list_pop, 1, pop_args, "pop");
-    base["len"] = CppFunction(list_len, 0, list_no_args, "len");
+    base["len"] = CppFunction(list_len, "len");
   }
 } list_startup;
 

--- a/objects.cpp
+++ b/objects.cpp
@@ -169,11 +169,11 @@ MapData_t::MapData_t(const MapData_t& other) {
     parent = 0;
   }
 }
-MapData_t::~MapData_t() { if(parent) delete parent; }
+MapData_t::~MapData_t() { if (parent) delete parent; }
 
 MapData_t& MapData_t::operator=(const MapData_t& other) {
   if (this != &other) {
-    if(parent) delete parent;
+    if (parent) delete parent;
     map = other.map;
     parent = other.parent;
   }

--- a/objects.cpp
+++ b/objects.cpp
@@ -31,36 +31,39 @@ packToken list_push(TokenMap scope) {
   packToken* token = scope.find("item");
 
   // If "this" is not a list it will throw here:
-  list->asList()->list.push_back(*token);
+  list->asList().list().push_back(*token);
 
   return *list;
 }
 
 const char* pop_args[] = {"pos"};
 packToken list_pop(TokenMap scope) {
-  TokenList* list = scope.find("this")->asList();
+  TokenList list = scope.find("this")->asList();
   packToken* token = scope.find("pos");
 
-  uint pos;
+  int64_t pos;
 
   if ((*token)->type == NUM) {
     pos = (uint)(token->asDouble());
+
+    // So that pop(-1) is the same as pop(last_idx):
+    if (pos < 0) pos = list.list().size()-pos;
   } else {
-    pos = list->list.size()-1;
+    pos = list.list().size()-1;
   }
 
-  packToken result = list->list[pos];
+  packToken result = list.list()[pos];
 
   // Erase the item from the list:
-  // Note that this operation is optimal if pos == list.size()
-  list->list.erase(list->list.begin() + pos);
+  // Note that this operation is optimal if pos == list.size()-1
+  list.list().erase(list.list().begin() + pos);
 
   return result;
 }
 
 packToken list_len(TokenMap scope) {
-  packList list = scope.find("this")->asList();
-  return list->list.size();
+  TokenList list = scope.find("this")->asList();
+  return list.list().size();
 }
 
 /* * * * * Initialize TokenList functions * * * * */

--- a/objects.h
+++ b/objects.h
@@ -21,7 +21,7 @@ struct Iterator {
   virtual void reset() = 0;
 };
 
-struct Iterable {
+struct Iterable : public TokenBase {
   virtual ~Iterable() {}
   virtual Iterator* getIterator() = 0;
 };
@@ -70,7 +70,7 @@ struct MapData_t {
   MapData_t& operator=(const MapData_t& other);
 };
 
-struct TokenMap : public pack<MapData_t>, public TokenBase, public Iterable {
+struct TokenMap : public pack<MapData_t>, public Iterable {
   // Static factories:
   static TokenMap empty;
   static TokenMap& base_map();
@@ -133,7 +133,7 @@ struct GlobalScope : public TokenMap {
 
 typedef std::vector<packToken> TokenList_t;
 
-class TokenList : public pack<TokenList_t>, public TokenBase, public Iterable {
+class TokenList : public pack<TokenList_t>, public Iterable {
  public:
   // Attribute getter for the
   // pack<TokenList_t> super class:

--- a/objects.h
+++ b/objects.h
@@ -12,7 +12,8 @@
 #include "./pack.h"
 
 // Iterator super class.
-struct Iterator {
+struct Iterator : public TokenBase {
+  Iterator() { this->type = IT; }
   virtual ~Iterator() {}
   // Return the next position of the iterator.
   // When it reaches the end it should return NULL
@@ -93,6 +94,10 @@ struct TokenMap : public pack<MapData_t>, public Iterable {
 
     packToken* next();
     void reset();
+
+    TokenBase* clone() const {
+      return new MapIterator(*this);
+    }
   };
 
   Iterator* getIterator() {
@@ -151,6 +156,10 @@ class TokenList : public pack<TokenList_t>, public Iterable {
 
     packToken* next();
     void reset();
+
+    TokenBase* clone() const {
+      return new ListIterator(*this);
+    }
   };
 
   Iterator* getIterator() {

--- a/pack.h
+++ b/pack.h
@@ -6,14 +6,15 @@
 #define PACK_H_
 
 // Pack a pointer to be automatically deleted:
-template<class T> class pack {
+template<typename T> class pack {
   // Reference Counter type:
   struct RC_t {
-    int count;
+    int64_t count;
     T* obj;
     bool _delete;
   };
 
+ public:
   typedef std::list<RC_t> RefList_t;
   typedef typename RefList_t::iterator Ref_t;
 
@@ -78,8 +79,14 @@ template<class T> class pack {
   operator T*() const { return ref->obj; }
   T* operator->() const { return ref->obj; }
   T& operator*() const { return *(ref->obj); }
-  T* get() const { return ref->obj; }
+  T* data() const { return ref->obj; }
+  int64_t count() const { return ref->count; }
+
+  friend bool operator==(pack<T> first, pack<T> second) {
+    return first.ref == second.ref;
+  }
 };
+
 
 #endif  // PACK_H_
 

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -8,6 +8,8 @@
 
 const packToken packToken::None = packToken(TokenNone());
 
+packToken::packToken(const TokenMap& map) : base(new TokenMap(map)) {}
+
 packToken& packToken::operator=(int t) {
   delete base;
   base = new Token<double>(t, NUM);
@@ -61,28 +63,28 @@ packToken& packToken::operator[](const std::string& key) {
     throw bad_cast(
       "The Token is not a map!");
   }
-  return (*static_cast<Token<packMap>*>(base)->val)[key];
+  return (*static_cast<TokenMap*>(base))[key];
 }
 const packToken& packToken::operator[](const std::string& key) const {
   if (base->type != MAP) {
     throw bad_cast(
       "The Token is not a map!");
   }
-  return (*static_cast<Token<packMap>*>(base)->val)[key];
+  return (*static_cast<TokenMap*>(base))[key];
 }
 packToken& packToken::operator[](const char* key) {
   if (base->type != MAP) {
     throw bad_cast(
       "The Token is not a map!");
   }
-  return (*static_cast<Token<packMap>*>(base)->val)[key];
+  return (*static_cast<TokenMap*>(base))[key];
 }
 const packToken& packToken::operator[](const char* key) const {
   if (base->type != MAP) {
     throw bad_cast(
       "The Token is not a map!");
   }
-  return (*static_cast<Token<packMap>*>(base)->val)[key];
+  return (*static_cast<TokenMap*>(base))[key];
 }
 
 bool packToken::asBool() const {
@@ -119,12 +121,12 @@ std::string& packToken::asString() const {
   return static_cast<Token<std::string>*>(base)->val;
 }
 
-packMap& packToken::asMap() const {
+TokenMap& packToken::asMap() const {
   if (base->type != MAP) {
     throw bad_cast(
       "The Token is not a map!");
   }
-  return static_cast<Token<packMap>*>(base)->val;
+  return *static_cast<TokenMap*>(base);
 }
 
 packList& packToken::asList() const {
@@ -149,8 +151,8 @@ std::string packToken::str() const {
 
 std::string packToken::str(const TokenBase* base) {
   std::stringstream ss;
-  TokenMap::TokenMap_t* tmap;
-  TokenMap::TokenMap_t::iterator m_it;
+  TokenMap_t* tmap;
+  TokenMap_t::iterator m_it;
 
   TokenList::TokenList_t* tlist;
   TokenList::TokenList_t::iterator l_it;
@@ -196,7 +198,7 @@ std::string packToken::str(const TokenBase* base) {
       ss << ")";
       return ss.str();
     case MAP:
-      tmap = &(static_cast<const Token<packMap>*>(base)->val->map);
+      tmap = &(static_cast<const TokenMap*>(base)->map());
       if (tmap->size() == 0) return "{}";
       ss << "{";
       for (m_it = tmap->begin(); m_it != tmap->end(); ++m_it) {

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -9,6 +9,7 @@
 const packToken packToken::None = packToken(TokenNone());
 
 packToken::packToken(const TokenMap& map) : base(new TokenMap(map)) {}
+packToken::packToken(const TokenList& list) : base(new TokenList(list)) {}
 
 packToken& packToken::operator=(int t) {
   delete base;
@@ -129,12 +130,12 @@ TokenMap& packToken::asMap() const {
   return *static_cast<TokenMap*>(base);
 }
 
-packList& packToken::asList() const {
+TokenList& packToken::asList() const {
   if (base->type != LIST) {
     throw bad_cast(
       "The Token is not a list!");
   }
-  return static_cast<Token<packList>*>(base)->val;
+  return *static_cast<TokenList*>(base);
 }
 
 Function* packToken::asFunc() const {
@@ -154,8 +155,8 @@ std::string packToken::str(const TokenBase* base) {
   TokenMap_t* tmap;
   TokenMap_t::iterator m_it;
 
-  TokenList::TokenList_t* tlist;
-  TokenList::TokenList_t::iterator l_it;
+  TokenList_t* tlist;
+  TokenList_t::iterator l_it;
   const Function* func;
   bool first;
   std::string name;
@@ -208,7 +209,7 @@ std::string packToken::str(const TokenBase* base) {
       ss << " }";
       return ss.str();
     case LIST:
-      tlist = &(static_cast<const Token<packList>*>(base)->val->list);
+      tlist = &(static_cast<const TokenList*>(base)->list());
       if (tlist->size() == 0) return "[]";
       ss << "[";
       for (l_it = tlist->begin(); l_it != tlist->end(); ++l_it) {

--- a/packToken.h
+++ b/packToken.h
@@ -25,7 +25,7 @@ class packToken {
   packToken(const char* s) : base(new Token<std::string>(s, STR)) {}
   packToken(const std::string& s) : base(new Token<std::string>(s, STR)) {}
   packToken(const TokenMap& map);
-  packToken(const packList& list) : base(new Token<packList>(list, LIST)) {}
+  packToken(const TokenList& list);
   ~packToken() { delete base; }
 
   packToken& operator=(int t);
@@ -45,7 +45,7 @@ class packToken {
   double asDouble() const;
   std::string& asString() const;
   TokenMap& asMap() const;
-  packList& asList() const;
+  TokenList& asList() const;
   Function* asFunc() const;
 
   std::string str() const;

--- a/packToken.h
+++ b/packToken.h
@@ -24,7 +24,7 @@ class packToken {
   packToken(double d) : base(new Token<double>(d, NUM)) {}
   packToken(const char* s) : base(new Token<std::string>(s, STR)) {}
   packToken(const std::string& s) : base(new Token<std::string>(s, STR)) {}
-  packToken(const packMap& map) : base(new Token<packMap>(map, MAP)) {}
+  packToken(const TokenMap& map);
   packToken(const packList& list) : base(new Token<packList>(list, LIST)) {}
   ~packToken() { delete base; }
 
@@ -44,7 +44,7 @@ class packToken {
   bool asBool() const;
   double asDouble() const;
   std::string& asString() const;
-  packMap& asMap() const;
+  TokenMap& asMap() const;
   packList& asList() const;
   Function* asFunc() const;
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -49,15 +49,8 @@ typedef std::queue<TokenBase*> TokenQueue_t;
 typedef std::map<std::string, int> OppMap_t;
 typedef std::list<TokenBase*> Tuple_t;
 
-// The pack template manages
-// reference counting.
-#include "./pack.h"
-
 class TokenMap;
-
 class TokenList;
-typedef pack<TokenList> packList;
-
 class Function;
 #include "./packToken.h"
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -54,7 +54,6 @@ typedef std::list<TokenBase*> Tuple_t;
 #include "./pack.h"
 
 class TokenMap;
-typedef pack<TokenMap> packMap;
 
 class TokenList;
 typedef pack<TokenList> packList;
@@ -96,13 +95,13 @@ class calculator {
   static typeMap_t& type_attribute_map();
 
  public:
-  static packToken calculate(const char* expr, packMap vars = &TokenMap::empty,
+  static packToken calculate(const char* expr, TokenMap vars = &TokenMap::empty,
                              const char* delim = 0, const char** rest = 0);
 
  private:
-  static TokenBase* calculate(TokenQueue_t RPN, packMap vars);
+  static TokenBase* calculate(TokenQueue_t RPN, TokenMap vars);
   static void cleanRPN(TokenQueue_t* rpn);
-  static TokenQueue_t toRPN(const char* expr, packMap vars,
+  static TokenQueue_t toRPN(const char* expr, TokenMap vars,
                             const char* delim = 0, const char** rest = 0,
                             OppMap_t opPrecedence = _opPrecedence);
 
@@ -123,13 +122,13 @@ class calculator {
   ~calculator();
   calculator() {}
   calculator(const calculator& calc);
-  calculator(const char* expr, packMap vars = &TokenMap::empty,
+  calculator(const char* expr, TokenMap vars = &TokenMap::empty,
              const char* delim = 0, const char** rest = 0,
              OppMap_t opPrecedence = _opPrecedence);
-  void compile(const char* expr, packMap vars = &TokenMap::empty,
+  void compile(const char* expr, TokenMap vars = &TokenMap::empty,
                const char* delim = 0, const char** rest = 0,
                OppMap_t opPrecedence = _opPrecedence);
-  packToken eval(packMap vars = &TokenMap::empty, bool keep_refs = false) const;
+  packToken eval(TokenMap vars = &TokenMap::empty, bool keep_refs = false) const;
 
   // Serialization:
   std::string str() const;

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -162,7 +162,7 @@ TEST_CASE("Test usage of functions `extend` function") {
 
 TEST_CASE("List usage expressions") {
   TokenMap vars;
-  vars["my_list"] = packList();
+  vars["my_list"] = TokenList();
 
   REQUIRE_NOTHROW(calculator::calculate("my_list.push(1)", vars));
   REQUIRE_NOTHROW(calculator::calculate("my_list.push(2)", vars));
@@ -180,7 +180,7 @@ TEST_CASE("List usage expressions") {
   REQUIRE(vars["my_list"].str() == "[ 1 ]");
   REQUIRE(calculator::calculate("my_list.len()", vars).asDouble() == 1);
 
-  vars["list"] = packList();
+  vars["list"] = TokenList();
   REQUIRE_NOTHROW(calculator::calculate("list.push(4).push(5).push(6)", vars));
   REQUIRE_NOTHROW(calculator::calculate("my_list.push(2).push(3)", vars));
   REQUIRE(vars["my_list"].str() == "[ 1, 2, 3 ]");
@@ -218,7 +218,7 @@ TEST_CASE("Test list iterable behavior") {
   GlobalScope vars;
   REQUIRE_NOTHROW(calculator::calculate("L = list(1,2,3)", vars));
   Iterator* it;
-  REQUIRE_NOTHROW(it = vars["L"].asList()->getIterator());
+  REQUIRE_NOTHROW(it = vars["L"].asList().getIterator());
   packToken* next;
   REQUIRE_NOTHROW(next = it->next());
   REQUIRE(next != 0);

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -3,8 +3,7 @@
 
 #include "./shunting-yard.h"
 
-TokenMap vars, emap;
-packMap tmap, key3;
+TokenMap vars, emap, tmap, key3;
 
 void PREPARE_ENVIRONMENT() {
   vars["pi"] = 3.14;
@@ -18,37 +17,37 @@ void PREPARE_ENVIRONMENT() {
   vars["str5"] = "10bar";
 
   vars["map"] = tmap;
-  (*tmap)["key"] = "mapped value";
-  (*tmap)["key1"] = "second mapped value";
-  (*tmap)["key2"] = 10;
-  (*tmap)["key3"] = key3;
-  (*tmap)["key3"]["map1"] = "inception1";
-  (*tmap)["key3"]["map2"] = "inception2";
+  tmap["key"] = "mapped value";
+  tmap["key1"] = "second mapped value";
+  tmap["key2"] = 10;
+  tmap["key3"] = key3;
+  tmap["key3"]["map1"] = "inception1";
+  tmap["key3"]["map2"] = "inception2";
 
   emap["a"] = 10;
   emap["b"] = 20;
 }
 
 TEST_CASE("Static calculate::calculate()") {
-  REQUIRE(calculator::calculate("-pi + 1", &vars).asDouble() == Approx(-2.14));
-  REQUIRE(calculator::calculate("-pi + 1 * b1", &vars).asDouble() == Approx(-3.14));
-  REQUIRE(calculator::calculate("(20+10)*3/2-3", &vars).asDouble() == Approx(42.0));
-  REQUIRE(calculator::calculate("1 << 4", &vars).asDouble() == Approx(16.0));
-  REQUIRE(calculator::calculate("1+(-2*3)", &vars).asDouble() == Approx(-5));
-  REQUIRE(calculator::calculate("1+_b+(-2*3)", &vars).asDouble() == Approx(-5));
+  REQUIRE(calculator::calculate("-pi + 1", vars).asDouble() == Approx(-2.14));
+  REQUIRE(calculator::calculate("-pi + 1 * b1", vars).asDouble() == Approx(-3.14));
+  REQUIRE(calculator::calculate("(20+10)*3/2-3", vars).asDouble() == Approx(42.0));
+  REQUIRE(calculator::calculate("1 << 4", vars).asDouble() == Approx(16.0));
+  REQUIRE(calculator::calculate("1+(-2*3)", vars).asDouble() == Approx(-5));
+  REQUIRE(calculator::calculate("1+_b+(-2*3)", vars).asDouble() == Approx(-5));
 }
 
 TEST_CASE("calculate::compile() and calculate::eval()") {
   calculator c1;
-  c1.compile("-pi+1", &vars);
+  c1.compile("-pi+1", vars);
   REQUIRE(c1.eval().asDouble() == Approx(-2.14));
 
-  calculator c2("pi+4", &vars);
+  calculator c2("pi+4", vars);
   REQUIRE(c2.eval().asDouble() == Approx(7.14));
   REQUIRE(c2.eval().asDouble() == Approx(7.14));
 
-  calculator c3("pi+b1+b2", &vars);
-  REQUIRE(c3.eval(&vars).asDouble() == Approx(4.0));
+  calculator c3("pi+b1+b2", vars);
+  REQUIRE(c3.eval(vars).asDouble() == Approx(4.0));
 }
 
 TEST_CASE("Boolean expressions") {
@@ -66,13 +65,13 @@ TEST_CASE("Boolean expressions") {
 }
 
 TEST_CASE("String expressions") {
-  REQUIRE(calculator::calculate("str1 + str2 == str3", &vars).asBool());
-  REQUIRE_FALSE(calculator::calculate("str1 + str2 != str3", &vars).asBool());
-  REQUIRE(calculator::calculate("str1 + 10 == str4", &vars).asBool());
-  REQUIRE(calculator::calculate("10 + str2 == str5", &vars).asBool());
+  REQUIRE(calculator::calculate("str1 + str2 == str3", vars).asBool());
+  REQUIRE_FALSE(calculator::calculate("str1 + str2 != str3", vars).asBool());
+  REQUIRE(calculator::calculate("str1 + 10 == str4", vars).asBool());
+  REQUIRE(calculator::calculate("10 + str2 == str5", vars).asBool());
 
-  REQUIRE(calculator::calculate("'foo' + \"bar\" == str3", &vars).asBool());
-  REQUIRE(calculator::calculate("'foo' + \"bar\" != 'foobar\"'", &vars).asBool());
+  REQUIRE(calculator::calculate("'foo' + \"bar\" == str3", vars).asBool());
+  REQUIRE(calculator::calculate("'foo' + \"bar\" != 'foobar\"'", vars).asBool());
 
   // Test escaping characters:
   REQUIRE(calculator::calculate("'foo\\'bar'").asString() == "foo'bar");
@@ -103,15 +102,15 @@ TEST_CASE("String formattting") {
 }
 
 TEST_CASE("Map access expressions") {
-  REQUIRE(calculator::calculate("map[\"key\"]", &vars).asString() == "mapped value");
-  REQUIRE(calculator::calculate("map[\"key\"+1]", &vars).asString() ==
+  REQUIRE(calculator::calculate("map[\"key\"]", vars).asString() == "mapped value");
+  REQUIRE(calculator::calculate("map[\"key\"+1]", vars).asString() ==
           "second mapped value");
-  REQUIRE(calculator::calculate("map[\"key\"+2] + 3 == 13", &vars).asBool() == true);
-  REQUIRE(calculator::calculate("map.key1", &vars).asString() == "second mapped value");
+  REQUIRE(calculator::calculate("map[\"key\"+2] + 3 == 13", vars).asBool() == true);
+  REQUIRE(calculator::calculate("map.key1", vars).asString() == "second mapped value");
 
-  REQUIRE(calculator::calculate("map.key3.map1", &vars).asString() == "inception1");
-  REQUIRE(calculator::calculate("map.key3['map2']", &vars).asString() == "inception2");
-  REQUIRE(calculator::calculate("map[\"no_key\"]", &vars) == packToken::None);
+  REQUIRE(calculator::calculate("map.key3.map1", vars).asString() == "inception1");
+  REQUIRE(calculator::calculate("map.key3['map2']", vars).asString() == "inception2");
+  REQUIRE(calculator::calculate("map[\"no_key\"]", vars) == packToken::None);
 }
 
 TEST_CASE("Prototypical inheritance tests") {
@@ -121,9 +120,9 @@ TEST_CASE("Prototypical inheritance tests") {
   TokenMap grand_child(&child);
 
   vars["a"] = 0;
-  vars["parent"] = packMap(&parent);
-  vars["child"] = packMap(&child);
-  vars["grand_child"] = packMap(&grand_child);
+  vars["parent"] = parent;
+  vars["child"] = child;
+  vars["grand_child"] = grand_child;
 
   parent["a"] = 10;
   parent["b"] = 20;
@@ -132,91 +131,92 @@ TEST_CASE("Prototypical inheritance tests") {
   child["c"] = 31;
   grand_child["c"] = 32;
 
-  REQUIRE(calculator::calculate("grand_child.a - 10", &vars).asDouble() == 0);
-  REQUIRE(calculator::calculate("grand_child.b - 20", &vars).asDouble() == 1);
-  REQUIRE(calculator::calculate("grand_child.c - 30", &vars).asDouble() == 2);
+  REQUIRE(calculator::calculate("grand_child.a - 10", vars).asDouble() == 0);
+  REQUIRE(calculator::calculate("grand_child.b - 20", vars).asDouble() == 1);
+  REQUIRE(calculator::calculate("grand_child.c - 30", vars).asDouble() == 2);
 
-  REQUIRE_NOTHROW(calculator::calculate("grand_child.a = 12", &vars));
-  REQUIRE(calculator::calculate("parent.a", &vars).asDouble() == 10);
-  REQUIRE(calculator::calculate("child.a", &vars).asDouble() == 10);
-  REQUIRE(calculator::calculate("grand_child.a", &vars).asDouble() == 12);
+  REQUIRE_NOTHROW(calculator::calculate("grand_child.a = 12", vars));
+  REQUIRE(calculator::calculate("parent.a", vars).asDouble() == 10);
+  REQUIRE(calculator::calculate("child.a", vars).asDouble() == 10);
+  REQUIRE(calculator::calculate("grand_child.a", vars).asDouble() == 12);
 }
 
 TEST_CASE("Test usage of functions `extend` function") {
   GlobalScope vars;
-  REQUIRE_NOTHROW(calculator::calculate("a = map()", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("b = extend(a)", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("a.a = 10", &vars));
-  REQUIRE(calculator::calculate("b.a", &vars).asDouble() == 10);
-  REQUIRE_NOTHROW(calculator::calculate("b.a = 20", &vars));
-  REQUIRE(calculator::calculate("a.a", &vars).asDouble() == 10);
-  REQUIRE(calculator::calculate("b.a", &vars).asDouble() == 20);
 
-  REQUIRE_NOTHROW(calculator::calculate("c = extend(b)", &vars));
-  REQUIRE(calculator::calculate("a.instanceof(b)", &vars).asBool() == false);
-  REQUIRE(calculator::calculate("a.instanceof(c)", &vars).asBool() == false);
-  REQUIRE(calculator::calculate("b.instanceof(a)", &vars).asBool() == true);
-  REQUIRE(calculator::calculate("c.instanceof(a)", &vars).asBool() == true);
-  REQUIRE(calculator::calculate("c.instanceof(b)", &vars).asBool() == true);
+  REQUIRE_NOTHROW(calculator::calculate("a = map()", vars));
+  REQUIRE_NOTHROW(calculator::calculate("b = extend(a)", vars));
+  REQUIRE_NOTHROW(calculator::calculate("a.a = 10", vars));
+  REQUIRE(calculator::calculate("b.a", vars).asDouble() == 10);
+  REQUIRE_NOTHROW(calculator::calculate("b.a = 20", vars));
+  REQUIRE(calculator::calculate("a.a", vars).asDouble() == 10);
+  REQUIRE(calculator::calculate("b.a", vars).asDouble() == 20);
+
+  REQUIRE_NOTHROW(calculator::calculate("c = extend(b)", vars));
+  REQUIRE(calculator::calculate("a.instanceof(b)", vars).asBool() == false);
+  REQUIRE(calculator::calculate("a.instanceof(c)", vars).asBool() == false);
+  REQUIRE(calculator::calculate("b.instanceof(a)", vars).asBool() == true);
+  REQUIRE(calculator::calculate("c.instanceof(a)", vars).asBool() == true);
+  REQUIRE(calculator::calculate("c.instanceof(b)", vars).asBool() == true);
 }
 
 TEST_CASE("List usage expressions") {
   TokenMap vars;
   vars["my_list"] = packList();
 
-  REQUIRE_NOTHROW(calculator::calculate("my_list.push(1)", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("my_list.push(2)", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("my_list.push(3)", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list.push(1)", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list.push(2)", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list.push(3)", vars));
 
   REQUIRE(vars["my_list"].str() == "[ 1, 2, 3 ]");
-  REQUIRE(calculator::calculate("my_list.len()", &vars).asDouble() == 3);
+  REQUIRE(calculator::calculate("my_list.len()", vars).asDouble() == 3);
 
-  REQUIRE_NOTHROW(calculator::calculate("my_list.pop(1)", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list.pop(1)", vars));
 
   REQUIRE(vars["my_list"].str() == "[ 1, 3 ]");
-  REQUIRE(calculator::calculate("my_list.len()", &vars).asDouble() == 2);
+  REQUIRE(calculator::calculate("my_list.len()", vars).asDouble() == 2);
 
-  REQUIRE_NOTHROW(calculator::calculate("my_list.pop()", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list.pop()", vars));
   REQUIRE(vars["my_list"].str() == "[ 1 ]");
-  REQUIRE(calculator::calculate("my_list.len()", &vars).asDouble() == 1);
+  REQUIRE(calculator::calculate("my_list.len()", vars).asDouble() == 1);
 
   vars["list"] = packList();
-  REQUIRE_NOTHROW(calculator::calculate("list.push(4).push(5).push(6)", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("my_list.push(2).push(3)", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("list.push(4).push(5).push(6)", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list.push(2).push(3)", vars));
   REQUIRE(vars["my_list"].str() == "[ 1, 2, 3 ]");
   REQUIRE(vars["list"].str() == "[ 4, 5, 6 ]");
 
-  REQUIRE_NOTHROW(calculator::calculate("concat = my_list + list", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("concat = my_list + list", vars));
   REQUIRE(vars["concat"].str() == "[ 1, 2, 3, 4, 5, 6 ]");
-  REQUIRE(calculator::calculate("concat.len()", &vars).asDouble() == 6);
+  REQUIRE(calculator::calculate("concat.len()", vars).asDouble() == 6);
 
   // Reverse index like python:
-  REQUIRE_NOTHROW(calculator::calculate("concat[-2] = 10", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("concat[2] = '3'", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("concat[3] = None", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("concat[-2] = 10", vars));
+  REQUIRE_NOTHROW(calculator::calculate("concat[2] = '3'", vars));
+  REQUIRE_NOTHROW(calculator::calculate("concat[3] = None", vars));
   REQUIRE(vars["concat"].str() == "[ 1, 2, \"3\", None, 10, 6 ]");
 
   // List index out of range:
-  REQUIRE_THROWS(calculator::calculate("concat[10]", &vars));
-  REQUIRE_THROWS(calculator::calculate("concat[-10]", &vars));
+  REQUIRE_THROWS(calculator::calculate("concat[10]", vars));
+  REQUIRE_THROWS(calculator::calculate("concat[-10]", vars));
 }
 
 TEST_CASE("List and map constructors usage") {
   GlobalScope vars;
-  REQUIRE_NOTHROW(calculator::calculate("my_map = map()", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("my_list = list()", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_map = map()", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list = list()", vars));
 
   REQUIRE(vars["my_map"]->type == MAP);
   REQUIRE(vars["my_list"]->type == LIST);
-  REQUIRE(calculator::calculate("my_list.len()", &vars).asDouble() == 0);
+  REQUIRE(calculator::calculate("my_list.len()", vars).asDouble() == 0);
 
-  REQUIRE_NOTHROW(calculator::calculate("my_list = list(1,'2',None,map(),list('sub_list'))", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list = list(1,'2',None,map(),list('sub_list'))", vars));
   REQUIRE(vars["my_list"].str() == "[ 1, \"2\", None, {}, [ \"sub_list\" ] ]");
 }
 
 TEST_CASE("Test list iterable behavior") {
   GlobalScope vars;
-  REQUIRE_NOTHROW(calculator::calculate("L = list(1,2,3)", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("L = list(1,2,3)", vars));
   Iterator* it;
   REQUIRE_NOTHROW(it = vars["L"].asList()->getIterator());
   packToken* next;
@@ -240,13 +240,13 @@ TEST_CASE("Test list iterable behavior") {
 
 TEST_CASE("Test map iterable behavior") {
   GlobalScope vars;
-  vars["M"] = packMap();
+  vars["M"] = TokenMap();
   vars["M"]["a"] = 1;
   vars["M"]["b"] = 2;
   vars["M"]["c"] = 3;
 
   Iterator* it;
-  REQUIRE_NOTHROW(it = vars["M"].asMap()->getIterator());
+  REQUIRE_NOTHROW(it = vars["M"].asMap().getIterator());
   packToken* next;
   REQUIRE_NOTHROW(next = it->next());
   REQUIRE(next != 0);
@@ -271,21 +271,21 @@ TEST_CASE("Function usage expressions") {
   vars["pi"] = 3.141592653589793;
   vars["a"] = -4;
 
-  REQUIRE(calculator::calculate("sqrt(4)", &vars).asDouble() == 2);
-  REQUIRE(calculator::calculate("sin(pi)", &vars).asDouble() == Approx(0));
-  REQUIRE(calculator::calculate("cos(pi/2)", &vars).asDouble() == Approx(0));
-  REQUIRE(calculator::calculate("tan(pi)", &vars).asDouble() == Approx(0));
+  REQUIRE(calculator::calculate("sqrt(4)", vars).asDouble() == 2);
+  REQUIRE(calculator::calculate("sin(pi)", vars).asDouble() == Approx(0));
+  REQUIRE(calculator::calculate("cos(pi/2)", vars).asDouble() == Approx(0));
+  REQUIRE(calculator::calculate("tan(pi)", vars).asDouble() == Approx(0));
   calculator c("a + sqrt(4) * 2");
-  REQUIRE(c.eval(&vars).asDouble() == 0);
-  REQUIRE(calculator::calculate("sqrt(4-a*3) * 2", &vars).asDouble() == 8);
-  REQUIRE(calculator::calculate("abs(42)", &vars).asDouble() == 42);
-  REQUIRE(calculator::calculate("abs(-42)", &vars).asDouble() == 42);
+  REQUIRE(c.eval(vars).asDouble() == 0);
+  REQUIRE(calculator::calculate("sqrt(4-a*3) * 2", vars).asDouble() == 8);
+  REQUIRE(calculator::calculate("abs(42)", vars).asDouble() == 42);
+  REQUIRE(calculator::calculate("abs(-42)", vars).asDouble() == 42);
 
   // With more than one argument:
-  REQUIRE(calculator::calculate("pow(2,2)", &vars).asDouble() == 4);
-  REQUIRE(calculator::calculate("pow(2,3)", &vars).asDouble() == 8);
-  REQUIRE(calculator::calculate("pow(2,a)", &vars).asDouble() == Approx(1./16));
-  REQUIRE(calculator::calculate("pow(2,a+4)", &vars).asDouble() == 1);
+  REQUIRE(calculator::calculate("pow(2,2)", vars).asDouble() == 4);
+  REQUIRE(calculator::calculate("pow(2,3)", vars).asDouble() == 8);
+  REQUIRE(calculator::calculate("pow(2,a)", vars).asDouble() == Approx(1./16));
+  REQUIRE(calculator::calculate("pow(2,a+4)", vars).asDouble() == 1);
 
   REQUIRE_THROWS(calculator::calculate("foo(10)"));
   REQUIRE_THROWS(calculator::calculate("foo(10),"));
@@ -300,26 +300,26 @@ TEST_CASE("Function usage expressions") {
   REQUIRE(calculator::calculate(" str('texto') ").asString() == "texto");
 
   vars["a"] = 0;
-  REQUIRE(calculator::calculate(" eval('a = 3') ", &vars).asDouble() == 3);
+  REQUIRE(calculator::calculate(" eval('a = 3') ", vars).asDouble() == 3);
   REQUIRE(vars["a"] == 3);
 
-  vars["m"] = packMap();
-  REQUIRE_THROWS(calculator::calculate("1 + float(m) * 3", &vars));
+  vars["m"] = TokenMap();
+  REQUIRE_THROWS(calculator::calculate("1 + float(m) * 3", vars));
   REQUIRE_THROWS(calculator::calculate("float('not a number')"));
 
   REQUIRE_NOTHROW(calculator::calculate("pow(1,-10)"));
   REQUIRE_NOTHROW(calculator::calculate("pow(1,+10)"));
 
   vars["base"] = 2;
-  c.compile("pow(base,2)", &vars);
+  c.compile("pow(base,2)", vars);
   vars["base"] = 3;
   REQUIRE(c.eval().asDouble() == 4);
-  REQUIRE(c.eval(&vars).asDouble() == 9);
+  REQUIRE(c.eval(vars).asDouble() == 9);
 }
 
 TEST_CASE("Multiple argument functions") {
   GlobalScope vars;
-  REQUIRE_NOTHROW(calculator::calculate("total = sum(1,2,3,4)", &vars));
+  REQUIRE_NOTHROW(calculator::calculate("total = sum(1,2,3,4)", vars));
   REQUIRE(vars["total"].asDouble() == 10);
 }
 
@@ -336,48 +336,48 @@ TEST_CASE("Type specific functions") {
   TokenMap vars;
   vars["s"] = "string";
 
-  REQUIRE(calculator::calculate("s.len()", &vars).asDouble() == 6);
+  REQUIRE(calculator::calculate("s.len()", vars).asDouble() == 6);
 }
 
 TEST_CASE("Assignment expressions") {
-  calculator::calculate("assignment = 10", &vars);
+  calculator::calculate("assignment = 10", vars);
 
   // Assigning to an unexistent variable works.
-  REQUIRE(calculator::calculate("assignment", &vars).asDouble() == 10);
+  REQUIRE(calculator::calculate("assignment", vars).asDouble() == 10);
 
   // Assigning to existent variables should work as well.
-  REQUIRE_NOTHROW(calculator::calculate("assignment = 20", &vars));
-  REQUIRE(calculator::calculate("assignment", &vars).asDouble() == 20);
+  REQUIRE_NOTHROW(calculator::calculate("assignment = 20", vars));
+  REQUIRE(calculator::calculate("assignment", vars).asDouble() == 20);
 
   // Chain assigning should work with a right-to-left order:
-  REQUIRE_NOTHROW(calculator::calculate("a = b = 20", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("a = b = c = d = 30", &vars));
-  REQUIRE(calculator::calculate("a == b && b == c && b == d && d == 30", &vars) == true);
+  REQUIRE_NOTHROW(calculator::calculate("a = b = 20", vars));
+  REQUIRE_NOTHROW(calculator::calculate("a = b = c = d = 30", vars));
+  REQUIRE(calculator::calculate("a == b && b == c && b == d && d == 30", vars) == true);
 
   REQUIRE_NOTHROW(calculator::calculate("teste='b'"));
 }
 
 TEST_CASE("Assignment expressions on maps") {
-  vars["m"] = packMap();
-  calculator::calculate("m['asn'] = 10", &vars);
+  vars["m"] = TokenMap();
+  calculator::calculate("m['asn'] = 10", vars);
 
   // Assigning to an unexistent variable works.
-  REQUIRE(calculator::calculate("m['asn']", &vars).asDouble() == 10);
+  REQUIRE(calculator::calculate("m['asn']", vars).asDouble() == 10);
 
   // Assigning to existent variables should work as well.
-  REQUIRE_NOTHROW(calculator::calculate("m['asn'] = 20", &vars));
-  REQUIRE(calculator::calculate("m['asn']", &vars).asDouble() == 20);
+  REQUIRE_NOTHROW(calculator::calculate("m['asn'] = 20", vars));
+  REQUIRE(calculator::calculate("m['asn']", vars).asDouble() == 20);
 
   // Chain assigning should work with a right-to-left order:
-  REQUIRE_NOTHROW(calculator::calculate("m.a = m.b = 20", &vars));
-  REQUIRE_NOTHROW(calculator::calculate("m.a = m.b = m.c = m.d = 30", &vars));
-  REQUIRE(calculator::calculate("m.a == m.b && m.b == m.c && m.b == m.d && m.d == 30", &vars) == true);
+  REQUIRE_NOTHROW(calculator::calculate("m.a = m.b = 20", vars));
+  REQUIRE_NOTHROW(calculator::calculate("m.a = m.b = m.c = m.d = 30", vars));
+  REQUIRE(calculator::calculate("m.a == m.b && m.b == m.c && m.b == m.d && m.d == 30", vars) == true);
 
-  REQUIRE_NOTHROW(calculator::calculate("m.m = m", &vars));
-  REQUIRE(calculator::calculate("10 + (a = m.a = m.m.b)", &vars) == 40);
+  REQUIRE_NOTHROW(calculator::calculate("m.m = m", vars));
+  REQUIRE(calculator::calculate("10 + (a = m.a = m.m.b)", vars) == 40);
 
-  REQUIRE_NOTHROW(calculator::calculate("m.m = None", &vars));
-  REQUIRE(calculator::calculate("m.m", &vars)->type == NONE);
+  REQUIRE_NOTHROW(calculator::calculate("m.m = None", vars));
+  REQUIRE(calculator::calculate("m.m", vars)->type == NONE);
 }
 
 TEST_CASE("Scope management") {
@@ -390,20 +390,20 @@ TEST_CASE("Scope management") {
   TokenMap child = parent.getChild();
 
   // Check scope extension:
-  REQUIRE(c.eval(&child).asDouble() == Approx(4));
+  REQUIRE(c.eval(child).asDouble() == Approx(4));
 
   child["b2"] = 1.0;
-  REQUIRE(c.eval(&child).asDouble() == Approx(4.14));
+  REQUIRE(c.eval(child).asDouble() == Approx(4.14));
 
   // Testing with 3 namespaces:
   TokenMap vmap = child.getChild();
   vmap["b1"] = -1.14;
-  REQUIRE(c.eval(&vmap).asDouble() == Approx(3.0));
+  REQUIRE(c.eval(vmap).asDouble() == Approx(3.0));
 
   TokenMap copy = vmap;
-  calculator c2("pi+b1+b2", &copy);
+  calculator c2("pi+b1+b2", copy);
   REQUIRE(c2.eval().asDouble() == Approx(3.0));
-  REQUIRE(calculator::calculate("pi+b1+b2", &copy).asDouble() == Approx(3.0));
+  REQUIRE(calculator::calculate("pi+b1+b2", copy).asDouble() == Approx(3.0));
 }
 
 // Working as a slave parser implies it will return
@@ -416,22 +416,22 @@ TEST_CASE("Parsing as slave parser") {
   calculator c1, c2, c3;
 
   // With static function:
-  REQUIRE_NOTHROW(calculator::calculate(code, &vars, ";}\n", &code));
+  REQUIRE_NOTHROW(calculator::calculate(code, vars, ";}\n", &code));
   REQUIRE(code == &(original_code[3]));
   REQUIRE(vars["a"].asDouble() == 1);
 
   // With constructor:
-  REQUIRE_NOTHROW((c2 = calculator(++code, &vars, ";}\n", &code)));
+  REQUIRE_NOTHROW((c2 = calculator(++code, vars, ";}\n", &code)));
   REQUIRE(code == &(original_code[8]));
 
   // With compile method:
-  REQUIRE_NOTHROW(c3.compile(++code, &vars, ";}\n", &code));
+  REQUIRE_NOTHROW(c3.compile(++code, vars, ";}\n", &code));
   REQUIRE(code == &(original_code[16]));
 
-  REQUIRE_NOTHROW(c2.eval(&vars));
+  REQUIRE_NOTHROW(c2.eval(vars));
   REQUIRE(vars["b"] == 2);
 
-  REQUIRE_NOTHROW(c3.eval(&vars));
+  REQUIRE_NOTHROW(c3.eval(vars));
   REQUIRE(vars["c"] == 3);
 
   // Testing with delimiter between brackets of the expression:
@@ -439,15 +439,15 @@ TEST_CASE("Parsing as slave parser") {
   const char* multiline = "a = (\n  1,\n  2,\n  3\n)\n print(a);";
 
   code = if_code;
-  REQUIRE_NOTHROW(calculator::calculate(if_code+4, &vars, ")", &code));
+  REQUIRE_NOTHROW(calculator::calculate(if_code+4, vars, ")", &code));
   REQUIRE(code == &(if_code[18]));
 
   code = multiline;
-  REQUIRE_NOTHROW(calculator::calculate(multiline, &vars, "\n;", &code));
+  REQUIRE_NOTHROW(calculator::calculate(multiline, vars, "\n;", &code));
   REQUIRE(code == &(multiline[21]));
 
   const char* error_test = "a = (;  1,;  2,; 3;)\n print(a);";
-  REQUIRE_THROWS(calculator::calculate(error_test, &vars, "\n;", &code));
+  REQUIRE_THROWS(calculator::calculate(error_test, vars, "\n;", &code));
 }
 
 TEST_CASE("Resource management") {
@@ -464,21 +464,21 @@ TEST_CASE("Resource management") {
 
 TEST_CASE("Exception management") {
   calculator ecalc;
-  ecalc.compile("a+b+del", &emap);
+  ecalc.compile("a+b+del", emap);
   emap["del"] = 30;
 
   REQUIRE_THROWS(calculator(""));
   REQUIRE_THROWS(calculator("      "));
 
   REQUIRE_THROWS(ecalc.eval());
-  REQUIRE_NOTHROW(ecalc.eval(&emap));
+  REQUIRE_NOTHROW(ecalc.eval(emap));
 
   emap.erase("del");
-  REQUIRE_THROWS(ecalc.eval(&emap));
+  REQUIRE_THROWS(ecalc.eval(emap));
 
   emap["del"] = 0;
   emap.erase("a");
-  REQUIRE_NOTHROW(ecalc.eval(&emap));
+  REQUIRE_NOTHROW(ecalc.eval(emap));
 
   REQUIRE_THROWS(calculator c5("10 + - - 10"));
   REQUIRE_THROWS(calculator c5("10 + +"));
@@ -486,11 +486,11 @@ TEST_CASE("Exception management") {
   REQUIRE_THROWS(calculator c5("c.[10]"));
 
   TokenMap v1;
-  v1["map"] = packMap();
+  v1["map"] = TokenMap();
   // Mismatched types, no supported operators.
-  REQUIRE_THROWS(calculator("map == 0").eval(&v1));
+  REQUIRE_THROWS(calculator("map == 0").eval(v1));
 
   // This test attempts to cause a memory leak:
   // To see if it still works run with `make check`
-  REQUIRE_THROWS(calculator::calculate("a+2*no_such_variable", &vars));
+  REQUIRE_THROWS(calculator::calculate("a+2*no_such_variable", vars));
 }


### PR DESCRIPTION
This PR is a major Refactor.

To make the garbage collector work, we created the `pack<>` template, that is responsible for keeping a reference to a map and/or a list avoiding to copy it often.

But this causes a problem: Now we have 2 pairs of classes that are basically the same thing:

`TokenMap` and `packMap` (i.e. `pack<TokenMap*>`)
`TokenList` and `packList` (i.e. `pack<TokenList*>`)

This redundancy might be confusing for our users and probably will make de code harder to maintain.
Other problem is that it is not possible to have a Token that is both: A `Map` and an `Iterable` because it would require us to make packMap Iterable, but it is a template built for other purpose.

With all that in mind we removed the `packMap` and `packList` typedefs, and made `TokenMap` and `TokenList` inherit from:

- `public pack<dataContainer>`
- `public Iterable`

And `Iterable` now inherits from `TokenBase` (since there is no meaning in having an iterable Token if it is not a Token).

This greatly improves the code readability, and seems to be the best architectural choice.

Besides this great Refactor there are 2 other changes:

- Functions internal variable `arglist` now is named `args` since it is easier to remember, and shorter.

- A new constructor was created for CppFunction class, so it is not necessary to create an empty argument list for 0 arguments built-in functions i.e. a minor refactor.
