### PR TITLE
Minor updates

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <cerrno>
 #include <iostream>
+#include <cctype>  // For tolower() and toupper()
 
 #include "./shunting-yard.h"
 #include "./functions.h"
@@ -218,7 +219,25 @@ packToken default_pow(TokenMap scope) {
 
 packToken string_len(TokenMap scope) {
   std::string str = scope.find("this")->asString();
-  return static_cast<int>(str.size());
+  return static_cast<int64_t>(str.size());
+}
+
+packToken string_lower(TokenMap scope) {
+  std::string str = scope.find("this")->asString();
+  std::string out;
+  for (char c : str) {
+    out.push_back(tolower(c));
+  }
+  return out;
+}
+
+packToken string_upper(TokenMap scope) {
+  std::string str = scope.find("this")->asString();
+  std::string out;
+  for (char c : str) {
+    out.push_back(toupper(c));
+  }
+  return out;
 }
 
 /* * * * * default constructor functions * * * * */
@@ -287,6 +306,8 @@ struct CppFunction::Startup {
 
     typeMap_t& type_map = calculator::type_attribute_map();
     type_map[STR]["len"] = CppFunction(&string_len, "len");
+    type_map[STR]["lower"] = CppFunction(&string_lower, "lower");
+    type_map[STR]["upper"] = CppFunction(&string_upper, "upper");
   }
 } CppFunction_startup;
 

--- a/functions.cpp
+++ b/functions.cpp
@@ -89,7 +89,7 @@ packToken default_eval(TokenMap scope) {
 
 packToken default_float(TokenMap scope) {
   packToken* tok = scope.find("value");
-  if ((*tok)->type == NUM) return *tok;
+  if ((*tok)->type & NUM) return tok->asDouble();
 
   // Convert it to double:
   char* rest;
@@ -101,6 +101,24 @@ packToken default_float(TokenMap scope) {
     throw std::runtime_error("Could not convert \"" + str + "\" to float!");
   } else if (errno) {
     std::range_error("Value too big or too small to fit a Double!");
+  }
+  return ret;
+}
+
+packToken default_int(TokenMap scope) {
+  packToken* tok = scope.find("value");
+  if ((*tok)->type & NUM) return tok->asInt();
+
+  // Convert it to double:
+  char* rest;
+  const std::string& str = tok->asString();
+  errno = 0;
+  int64_t ret = strtol(str.c_str(), &rest, 10);
+
+  if (str == rest) {
+    throw std::runtime_error("Could not convert \"" + str + "\" to integer!");
+  } else if (errno) {
+    std::range_error("Value too big or too small to fit an Integer!");
   }
   return ret;
 }
@@ -117,7 +135,8 @@ packToken default_type(TokenMap scope) {
   switch ((*tok)->type) {
   case NONE: return "none";
   case VAR: return "variable";
-  case NUM: return "number";
+  case REAL: return "float";
+  case INT: return "integer";
   case STR: return "string";
   case FUNC: return "function";
   case IT: return "iterable";

--- a/functions.cpp
+++ b/functions.cpp
@@ -227,8 +227,8 @@ packToken default_list(TokenMap scope) {
   // Get the arguments:
   TokenList list = scope.find("args")->asList();
 
-  // If the only argument is a tuple:
-  if (list.list().size() == 1 && list.list()[0]->type == TUPLE) {
+  // If the only argument is iterable:
+  if (list.list().size() == 1 && list.list()[0]->type & IT) {
     return TokenList(list.list()[0]);
   } else {
     return list;

--- a/objects.cpp
+++ b/objects.cpp
@@ -194,18 +194,6 @@ packToken* TokenMap::find(std::string key) {
   }
 }
 
-const packToken* TokenMap::find(std::string key) const {
-  TokenMap_t::const_iterator it = map().find(key);
-
-  if (it != map().end()) {
-    return &it->second;
-  } else if (parent()) {
-    return parent()->find(key);
-  } else {
-    return 0;
-  }
-}
-
 void TokenMap::assign(std::string key, TokenBase* value) {
   if (value) {
     value = value->clone();

--- a/objects.cpp
+++ b/objects.cpp
@@ -194,6 +194,18 @@ packToken* TokenMap::find(std::string key) {
   }
 }
 
+TokenMap* TokenMap::findMap(std::string key) {
+  TokenMap_t::iterator it = map().find(key);
+
+  if (it != map().end()) {
+    return this;
+  } else if (parent()) {
+    return parent()->findMap(key);
+  } else {
+    return 0;
+  }
+}
+
 void TokenMap::assign(std::string key, TokenBase* value) {
   if (value) {
     value = value->clone();

--- a/objects.cpp
+++ b/objects.cpp
@@ -43,8 +43,8 @@ packToken list_pop(TokenMap scope) {
 
   int64_t pos;
 
-  if ((*token)->type == NUM) {
-    pos = (uint)(token->asDouble());
+  if ((*token)->type & NUM) {
+    pos = token->asInt();
 
     // So that pop(-1) is the same as pop(last_idx):
     if (pos < 0) pos = list.list().size()-pos;

--- a/objects.h
+++ b/objects.h
@@ -120,6 +120,7 @@ struct TokenMap : public pack<MapData_t>, public Iterable {
 
  public:
   packToken* find(std::string key);
+  TokenMap* findMap(std::string key);
   void assign(std::string key, TokenBase* value);
   void insert(std::string key, TokenBase* value);
 

--- a/objects.h
+++ b/objects.h
@@ -120,7 +120,6 @@ struct TokenMap : public pack<MapData_t>, public Iterable {
 
  public:
   packToken* find(std::string key);
-  const packToken* find(std::string key) const;
   void assign(std::string key, TokenBase* value);
   void insert(std::string key, TokenBase* value);
 

--- a/objects.h
+++ b/objects.h
@@ -213,6 +213,7 @@ class TokenList : public pack<TokenList_t>, public Iterable {
     packToken* next = it->next();
     while (next) {
       list().push_back(*next);
+      next = it->next();
     }
 
     delete it;

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -17,7 +17,6 @@ packToken& packToken::operator=(const packToken& t) {
   return *this;
 }
 
-// Used mainly for testing
 bool packToken::operator==(const packToken& token) const {
   if (NUM & token.base->type & base->type) {
     return token.asDouble() == asDouble();
@@ -29,6 +28,10 @@ bool packToken::operator==(const packToken& token) const {
     // Compare strings to simplify code
     return token.str().compare(str()) == 0;
   }
+}
+
+bool packToken::operator!=(const packToken& token) const {
+  return !(*this == token);
 }
 
 TokenBase* packToken::operator->() const {

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -200,7 +200,13 @@ std::string packToken::str(const TokenBase* base) {
         }
         ss << str(token);
       }
-      ss << ")";
+      if (first) {
+        // Its an empty tuple:
+        // Add a `,` to make it different than ():
+        ss << ",)";
+      } else {
+        ss << ")";
+      }
       return ss.str();
     case MAP:
       tmap = &(static_cast<const TokenMap*>(base)->map());

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -11,30 +11,6 @@ const packToken packToken::None = packToken(TokenNone());
 packToken::packToken(const TokenMap& map) : base(new TokenMap(map)) {}
 packToken::packToken(const TokenList& list) : base(new TokenList(list)) {}
 
-packToken& packToken::operator=(int t) {
-  delete base;
-  base = new Token<int64_t>(t, INT);
-  return *this;
-}
-
-packToken& packToken::operator=(double t) {
-  delete base;
-  base = new Token<double>(t, REAL);
-  return *this;
-}
-
-packToken& packToken::operator=(const char* t) {
-  delete base;
-  base = new Token<std::string>(t, STR);
-  return *this;
-}
-
-packToken& packToken::operator=(const std::string& t) {
-  delete base;
-  base = new Token<std::string>(t, STR);
-  return *this;
-}
-
 packToken& packToken::operator=(const packToken& t) {
   delete base;
   base = t.base->clone();

--- a/packToken.h
+++ b/packToken.h
@@ -18,10 +18,11 @@ class packToken {
 
   template<class C>
   packToken(C c, tokType type) : base(new Token<C>(c, type)) {}
-  packToken(int d) : base(new Token<double>(d, NUM)) {}
-  packToken(int64_t l) : base(new Token<double>(l, NUM)) {}
-  packToken(size_t s) : base(new Token<double>(s, NUM)) {}
-  packToken(double d) : base(new Token<double>(d, NUM)) {}
+  packToken(int d) : base(new Token<int64_t>(d, INT)) {}
+  packToken(int64_t l) : base(new Token<int64_t>(l, INT)) {}
+  packToken(size_t s) : base(new Token<int64_t>(s, INT)) {}
+  packToken(float f) : base(new Token<double>(f, REAL)) {}
+  packToken(double d) : base(new Token<double>(d, REAL)) {}
   packToken(const char* s) : base(new Token<std::string>(s, STR)) {}
   packToken(const std::string& s) : base(new Token<std::string>(s, STR)) {}
   packToken(const TokenMap& map);
@@ -43,6 +44,7 @@ class packToken {
 
   bool asBool() const;
   double asDouble() const;
+  int64_t asInt() const;
   std::string& asString() const;
   TokenMap& asMap() const;
   TokenList& asList() const;

--- a/packToken.h
+++ b/packToken.h
@@ -31,6 +31,7 @@ class packToken {
 
   TokenBase* operator->() const;
   bool operator==(const packToken& t) const;
+  bool operator!=(const packToken& t) const;
   packToken& operator[](const std::string& key);
   packToken& operator[](const char* key);
   const packToken& operator[](const std::string& key) const;

--- a/packToken.h
+++ b/packToken.h
@@ -29,10 +29,6 @@ class packToken {
   packToken(const TokenList& list);
   ~packToken() { delete base; }
 
-  packToken& operator=(int t);
-  packToken& operator=(double t);
-  packToken& operator=(const char* t);
-  packToken& operator=(const std::string& t);
   TokenBase* operator->() const;
   bool operator==(const packToken& t) const;
   packToken& operator[](const std::string& key);

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -452,7 +452,15 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn, TokenMap vars) {
             std::string& key = r_left.asString();
             map[key] = packToken(b_right->clone());
           } else if (vars) {
-            vars.assign(r_left.asString(), b_right);
+            TokenMap* map = vars.findMap(r_left.asString());
+            if (!map || *map == TokenMap::default_global()) {
+              // Assign on the local scope.
+              // The user should not be able to implicitly overwrite
+              // variables he did not declare, since it's error prone.
+              vars[r_left.asString()] = packToken(b_right->clone());
+            } else {
+              (*map)[r_left.asString()] = packToken(b_right->clone());
+            }
           } else {
             delete b_right;
             cleanStack(evaluation);

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -696,6 +696,24 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn, TokenMap vars) {
         if (!op.compare("+")) {
           ss << left << right;
           evaluation.push(new Token<std::string>(ss.str(), STR));
+        } else if (!op.compare("[]")) {
+          int64_t index = right;
+
+          if (index < 0) {
+            // Reverse index, i.e. list[-1] = list[list.size()-1]
+            index += left.size();
+          }
+
+          if (index < 0 || static_cast<size_t>(index) >= left.size()) {
+            delete b_left;
+            cleanStack(evaluation);
+            throw std::domain_error("String index out of range!");
+          }
+
+          std::string value;
+          value.push_back(left[index]);
+
+          evaluation.push(new Token<std::string>(value, STR));
         } else {
           cleanStack(evaluation);
           throw undefined_operation(op, left, right);

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -301,19 +301,31 @@ TokenQueue_t calculator::toRPN(const char* expr,
           rpnQueue.push(new Tuple());
           lastTokenWasOp = false;
         }
-        while (operatorStack.top().compare("(")) {
+        while (operatorStack.size() && operatorStack.top().compare("(")) {
           rpnQueue.push(new Token<std::string>(operatorStack.top(), OP));
           operatorStack.pop();
         }
+
+        if (operatorStack.size() == 0) {
+          cleanRPN(&rpnQueue);
+          throw syntax_error("Extra ')' on the expression!");
+        }
+
         operatorStack.pop();
         --bracketLevel;
         ++expr;
         break;
       case ']':
-        while (operatorStack.top().compare("[")) {
+        while (operatorStack.size() && operatorStack.top().compare("[")) {
           rpnQueue.push(new Token<std::string>(operatorStack.top(), OP));
           operatorStack.pop();
         }
+
+        if (operatorStack.size() == 0) {
+          cleanRPN(&rpnQueue);
+          throw syntax_error("Extra ']' on the expression!");
+        }
+
         operatorStack.pop();
         --bracketLevel;
         ++expr;

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -508,6 +508,26 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn, TokenMap vars) {
           cleanStack(evaluation);
           throw undefined_operation(op, r_left, p_right);
         }
+      } else if (!op.compare("==")) {
+        packToken left(b_left);
+        packToken right(b_right);
+
+        if (left->type == VAR || right->type == VAR) {
+          cleanStack(evaluation);
+          throw undefined_operation(op, left, right);
+        }
+
+        evaluation.push(new Token<int64_t>(left == right, INT));
+      } else if (!op.compare("!=")) {
+        packToken left(b_left);
+        packToken right(b_right);
+
+        if (left->type == VAR || right->type == VAR) {
+          cleanStack(evaluation);
+          throw undefined_operation(op, left, right);
+        }
+
+        evaluation.push(new Token<int64_t>(left != right, INT));
       } else if (b_left->type == MAP && b_right->type == STR) {
         TokenMap left = *static_cast<TokenMap*>(b_left);
         std::string right = static_cast<Token<std::string>*>(b_right)->val;
@@ -598,10 +618,6 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn, TokenMap vars) {
           evaluation.push(new Token<double>(left <= right, NUM));
         } else if (!op.compare(">=")) {
           evaluation.push(new Token<double>(left >= right, NUM));
-        } else if (!op.compare("==")) {
-          evaluation.push(new Token<double>(left == right, NUM));
-        } else if (!op.compare("!=")) {
-          evaluation.push(new Token<double>(left != right, NUM));
         } else if (!op.compare("&&")) {
           evaluation.push(new Token<double>(left_i && right_i, NUM));
         } else if (!op.compare("||")) {

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -9,7 +9,12 @@
 
 enum tokType {
   // Base types:
-  NONE, OP, VAR, NUM, STR, FUNC,
+  NONE, OP, VAR, STR, FUNC,
+
+  // Numerals:
+  NUM = 0x8,  // Everything with the bit 0x8 set is a number.
+  REAL = 0x8, // == 0x8 => Real numbers.
+  INT = 0x9,  // == 0x8 + 0x1 => Integers are numbers.
 
   // Complex types:
   IT = 0x20,     // Everything with the bit 0x20 set is an iterator.

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -12,9 +12,9 @@ enum tokType {
   NONE, OP, VAR, STR, FUNC,
 
   // Numerals:
-  NUM = 0x8,  // Everything with the bit 0x8 set is a number.
-  REAL = 0x8, // == 0x8 => Real numbers.
-  INT = 0x9,  // == 0x8 + 0x1 => Integers are numbers.
+  NUM = 0x8,   // Everything with the bit 0x8 set is a number.
+  REAL = 0x8,  // == 0x8 => Real numbers.
+  INT = 0x9,   // == 0x8 + 0x1 => Integers are numbers.
 
   // Complex types:
   IT = 0x20,     // Everything with the bit 0x20 set is an iterator.

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -325,7 +325,8 @@ TEST_CASE("Multiple argument functions") {
 
 TEST_CASE("Default functions") {
   REQUIRE(calculator::calculate("type(None)").asString() == "none");
-  REQUIRE(calculator::calculate("type(10)").asString() == "number");
+  REQUIRE(calculator::calculate("type(10.0)").asString() == "float");
+  REQUIRE(calculator::calculate("type(10)").asString() == "integer");
   REQUIRE(calculator::calculate("type('str')").asString() == "string");
   REQUIRE(calculator::calculate("type(str)").asString() == "function");
   REQUIRE(calculator::calculate("type(list())").asString() == "list");

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -508,4 +508,8 @@ TEST_CASE("Exception management") {
   // This test attempts to cause a memory leak:
   // To see if it still works run with `make check`
   REQUIRE_THROWS(calculator::calculate("a+2*no_such_variable", vars));
+
+  REQUIRE_THROWS(calculator("print('hello'))"));
+  REQUIRE_THROWS(calculator("map()['hello']]"));
+  REQUIRE_THROWS(calculator("map(['hello']]"));
 }

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -89,7 +89,8 @@ TEST_CASE("String expressions") {
   REQUIRE(calculator::calculate("'foo\\\nar'").asString() == "foo\nar");
 }
 
-TEST_CASE("String formattting") {
+TEST_CASE("String operations") {
+  // String formatting:
   REQUIRE(calculator::calculate("'the test %s working' % 'is'").asString() == "the test is working");
   REQUIRE(calculator::calculate("'the tests %s %s' % ('are', 'working')").asString() == "the tests are working");
 
@@ -99,6 +100,12 @@ TEST_CASE("String formattting") {
 
   REQUIRE_THROWS(calculator::calculate("'the tests %s' % ('are', 'working')"));
   REQUIRE_THROWS(calculator::calculate("'the tests %s %s' % ('are')"));
+
+  // String indexing:
+  REQUIRE(calculator::calculate("'foobar'[0]").asString() == "f");
+  REQUIRE(calculator::calculate("'foobar'[3]").asString() == "b");
+  REQUIRE(calculator::calculate("'foobar'[-1]").asString() == "r");
+  REQUIRE(calculator::calculate("'foobar'[-3]").asString() == "b");
 }
 
 TEST_CASE("Map access expressions") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -62,6 +62,11 @@ TEST_CASE("Boolean expressions") {
   REQUIRE_FALSE(calculator::calculate("(3 && 0) == True").asBool());
   REQUIRE(calculator::calculate("(3 || 0) == True").asBool());
   REQUIRE_FALSE(calculator::calculate("(False || 0) == True").asBool());
+
+  REQUIRE_FALSE(calculator::calculate("10 == None").asBool());
+  REQUIRE(calculator::calculate("10 != None").asBool());
+  REQUIRE_FALSE(calculator::calculate("10 == 'str'").asBool());
+  REQUIRE(calculator::calculate("10 != 'str'").asBool());
 }
 
 TEST_CASE("String expressions") {
@@ -518,7 +523,7 @@ TEST_CASE("Exception management") {
   TokenMap v1;
   v1["map"] = TokenMap();
   // Mismatched types, no supported operators.
-  REQUIRE_THROWS(calculator("map == 0").eval(v1));
+  REQUIRE_THROWS(calculator("map * 0").eval(v1));
 
   // This test attempts to cause a memory leak:
   // To see if it still works run with `make check`

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -212,6 +212,13 @@ TEST_CASE("List and map constructors usage") {
 
   REQUIRE_NOTHROW(calculator::calculate("my_list = list(1,'2',None,map(),list('sub_list'))", vars));
   REQUIRE(vars["my_list"].str() == "[ 1, \"2\", None, {}, [ \"sub_list\" ] ]");
+
+  // Test initialization by Iterator:
+  REQUIRE_NOTHROW(calculator::calculate("my_map  = map()", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_map.a = 1", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_map.b = 2", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_list  = list(my_map)", vars));
+  REQUIRE(vars["my_list"].str() == "[ \"a\", \"b\" ]");
 }
 
 TEST_CASE("Test list iterable behavior") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -354,9 +354,11 @@ TEST_CASE("Default functions") {
 
 TEST_CASE("Type specific functions") {
   TokenMap vars;
-  vars["s"] = "string";
+  vars["s"] = "String";
 
   REQUIRE(calculator::calculate("s.len()", vars).asDouble() == 6);
+  REQUIRE(calculator::calculate("s.lower()", vars).asString() == "string");
+  REQUIRE(calculator::calculate("s.upper()", vars).asString() == "STRING");
 }
 
 TEST_CASE("Assignment expressions") {


### PR DESCRIPTION
This PR, contains some bug fixing, some refactoring and among them the most important are:

- Add a TokenMap::findMap() function, works like find() but return the original map. Can be useful when managing references to variables, to make sure it will point to the original variable, on the original map. (pointing the reference directly to the variable would not be safe since the garbage collector only guarantee access to map and list references).

- Protect global scope from assignments; Now if the user wants to change the global scope it will need to have a reference to it, i.e. a `global` built-in variable referencing the global scope.

- Add the integer (INT) type. It does not add operations to work with it, but all operations that work with doubles were adapted to accept integers as well.

- The list constructor now accepts an iterable as argument instead of a Tuple (Tuples are Iterable).

- Add string indexing i.e.: 'foobar'[0] == 'f' // True

- Operators `==` and `!=` work with any type now. For example the integer 10 equals the real number 10.0, but differs from a function or a list.

- Add 'str'.upper() and 'str'.lower() functions.