### PR TITLE
Improve support to Map and Tuple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ $(EXE): $(OBJ); $(CXX) $(CFLAGS) $(OBJ) -o $(EXE)
 
 again: clean all
 
-test: $(EXE); ./$(EXE)
+test: $(EXE); ./$(EXE) $(args)
 
-check: $(EXE); valgrind --leak-check=full ./$(EXE)
+check: $(EXE); valgrind --leak-check=full ./$(EXE) $(args)
 
 clean: ; rm -f $(EXE) $(OBJ)

--- a/functions.cpp
+++ b/functions.cpp
@@ -145,6 +145,7 @@ packToken default_type(TokenMap scope) {
   case FUNC: return "function";
   case IT: return "iterable";
   case TUPLE: return "tuple";
+  case STUPLE: return "argument tuple";
   case LIST: return "list";
   case MAP: return "map";
   default: return "unknown_type";

--- a/functions.cpp
+++ b/functions.cpp
@@ -9,35 +9,82 @@
 
 #include "./shunting-yard.h"
 #include "./functions.h"
+#include "./shunting-yard-exceptions.h"
 
 /* * * * * class Function * * * * */
 packToken Function::call(packToken _this, Function* func,
                          TokenList* args, TokenMap scope) {
   // Build the local namespace:
+  TokenMap kwargs;
   TokenMap local = scope.getChild();
-  TokenList_t::iterator it = args->list().begin();
 
-  // Add args to local namespace:
-  for (const std::string& name : func->args()) {
-    packToken value;
-    if (it != args->list().end()) {
-      value = packToken(*it);
-      ++it;
-    } else {
-      value = packToken::None;
-    }
+  argsList arg_names = func->args();
 
-    local[name] = value;
+  TokenList_t::iterator args_it = args->list().begin();
+  argsList::const_iterator names_it = arg_names.begin();
+
+  /* * * * * Parse named arguments: * * * * */
+
+  while (args_it != args->list().end() && names_it != arg_names.end()) {
+    // If the positional argument list is over:
+    if ((*args_it)->type == STUPLE) break;
+
+    // Else add it to the local namespace:
+    local[*names_it] = *args_it;
+
+    ++args_it;
+    ++names_it;
   }
+
+  /* * * * * Parse extra positional arguments: * * * * */
 
   TokenList arglist;
-  // Collect any extra arguments:
-  while (it != args->list().end()) {
-    arglist.list().push_back(packToken(*it));
-    ++it;
+  for (; args_it != args->list().end(); ++args_it) {
+    // If there is a keyword argument:
+    if ((*args_it)->type == STUPLE) break;
+    // Else add it to arglist:
+    arglist.list().push_back(*args_it);
   }
-  local["args"] = arglist;
+
+  /* * * * * Parse keyword arguments: * * * * */
+
+  for (; args_it != args->list().end(); ++args_it) {
+    packToken& arg = *args_it;
+
+    if (arg->type != STUPLE) {
+      throw syntax_error("Positional argument follows keyword argument");
+    }
+
+    STuple* st = static_cast<STuple*>(arg.token());
+
+    if (st->list().size() != 2) {
+      throw syntax_error("Keyword tuples must have exactly 2 items!");
+    }
+
+    if (st->list()[0]->type != STR) {
+      throw syntax_error("Keyword first argument should be of type string!");
+    }
+
+    // Save it:
+    std::string key = st->list()[0].asString();
+    packToken& value = st->list()[1];
+    kwargs[key] = value;
+  }
+
+  /* * * * * Set missing arguments to None: * * * * */
+
+  for (; names_it != arg_names.end(); ++names_it) {
+    // If not set by a keyword argument:
+    if (local.map().count(*names_it) == 0) {
+      local[*names_it] = packToken::None;
+    }
+  }
+
+  /* * * * * Set built-in variables: * * * * */
+
   local["this"] = _this;
+  local["args"] = arglist;
+  local["kwargs"] = kwargs;
 
   return func->exec(local);
 }
@@ -269,7 +316,7 @@ packToken default_list(TokenMap scope) {
 }
 
 packToken default_map(TokenMap scope) {
-  return TokenMap();
+  return scope["kwargs"];
 }
 
 /* * * * * class CppFunction * * * * */

--- a/functions.h
+++ b/functions.h
@@ -7,7 +7,7 @@
 class Function : public TokenBase {
  public:
   static packToken call(packToken _this, Function* func,
-                        Tuple* args, TokenMap scope);
+                        TokenList* args, TokenMap scope);
 
  public:
   typedef std::list<std::string> argsList;

--- a/objects.cpp
+++ b/objects.cpp
@@ -111,59 +111,6 @@ packToken* TokenList::ListIterator::next() {
 
 void TokenList::ListIterator::reset() { i = 0; }
 
-/* * * * * Tuple Functions: * * * * */
-
-Tuple::Tuple(const TokenBase* a) {
-  tuple.push_back(a->clone());
-  this->type = TUPLE;
-}
-
-Tuple::Tuple(const TokenBase* a, const TokenBase* b) {
-  tuple.push_back(a->clone());
-  tuple.push_back(b->clone());
-  this->type = TUPLE;
-}
-
-void Tuple::push_back(const TokenBase* tb) {
-  tuple.push_back(tb->clone());
-}
-
-TokenBase* Tuple::pop_front() {
-  if (tuple.size() == 0) {
-    throw std::range_error("Can't pop front of an empty Tuple!");
-  }
-
-  TokenBase* value = tuple.front();
-  tuple.pop_front();
-  return value;
-}
-
-unsigned int Tuple::size() {
-  return tuple.size();
-}
-
-Tuple::Tuple_t Tuple::copyTuple(const Tuple_t& t) {
-  Tuple_t copy;
-  Tuple_t::const_iterator it;
-  for (it = t.begin(); it != t.end(); ++it) {
-    copy.push_back((*it)->clone());
-  }
-  return copy;
-}
-
-void Tuple::cleanTuple(Tuple_t* t) {
-  while (t->size()) {
-    delete t->back();
-    t->pop_back();
-  }
-}
-
-Tuple& Tuple::operator=(const Tuple& t) {
-  cleanTuple(&tuple);
-  tuple = copyTuple(t.tuple);
-  return *this;
-}
-
 /* * * * * MapData_t struct: * * * * */
 
 MapData_t::MapData_t(TokenMap* p) : parent(p ? new TokenMap(*p) : 0) {}

--- a/objects.cpp
+++ b/objects.cpp
@@ -23,6 +23,34 @@ TokenMap& TokenMap::default_global() {
 
 TokenMap TokenMap::empty = TokenMap(&default_global());
 
+/* * * * * TokenMap built-in functions * * * * */
+
+const char* map_pop_args[] = {"key", "default"};
+packToken map_pop(TokenMap scope) {
+  TokenMap map = scope["this"].asMap();
+  std::string key = scope["key"].asString();
+
+  // Check if the item is available and remove it:
+  if (map.map().count(key)) {
+    packToken value = map[key];
+    map.erase(key);
+    return value;
+  }
+
+  // If not available return the default value or None
+  packToken* def = scope.find("default");
+  if (def) {
+    return *def;
+  } else {
+    return packToken::None;
+  }
+}
+
+packToken map_len(TokenMap scope) {
+  TokenMap map = scope.find("this")->asMap();
+  return map.map().size();
+}
+
 /* * * * * TokenList built-in functions * * * * */
 
 const char* push_args[] = {"item"};
@@ -36,7 +64,7 @@ packToken list_push(TokenMap scope) {
   return *list;
 }
 
-const char* pop_args[] = {"pos"};
+const char* list_pop_args[] = {"pos"};
 packToken list_pop(TokenMap scope) {
   TokenList list = scope.find("this")->asList();
   packToken* token = scope.find("pos");
@@ -70,10 +98,14 @@ packToken list_len(TokenMap scope) {
 
 struct TokenList::Startup {
   Startup() {
-    TokenMap& base = calculator::type_attribute_map()[LIST];
-    base["push"] = CppFunction(list_push, 1, push_args, "push");
-    base["pop"] = CppFunction(list_pop, 1, pop_args, "pop");
-    base["len"] = CppFunction(list_len, "len");
+    TokenMap& base_list = calculator::type_attribute_map()[LIST];
+    base_list["push"] = CppFunction(list_push, 1, push_args, "push");
+    base_list["pop"] = CppFunction(list_pop, 1, list_pop_args, "pop");
+    base_list["len"] = CppFunction(list_len, "len");
+
+    TokenMap& base_map = TokenMap::base_map();
+    base_map["pop"] = CppFunction(map_pop, 2, map_pop_args, "pop");
+    base_map["len"] = CppFunction(map_len, "len");
   }
 } list_startup;
 

--- a/objects.cpp
+++ b/objects.cpp
@@ -77,6 +77,12 @@ struct TokenList::Startup {
   }
 } list_startup;
 
+/* * * * * Iterator functions * * * * */
+
+Iterator*  Iterator::getIterator() {
+  return static_cast<Iterator*>(this->clone());
+}
+
 /* * * * * TokenMap iterator implemented functions * * * * */
 
 packToken* TokenMap::MapIterator::next() {

--- a/objects.h
+++ b/objects.h
@@ -31,65 +31,6 @@ struct Iterator : public Iterable {
   Iterator* getIterator();
 };
 
-class Tuple : public Iterable {
- public:
-  typedef std::list<TokenBase*> Tuple_t;
-
- private:
-  struct TupleIterator : public Iterator {
-    Tuple_t* list;
-    Tuple_t::const_iterator it;
-    packToken last;
-
-    TupleIterator(Tuple_t* list) : it(list->begin()) {}
-    packToken* next() {
-      if (it != list->end()) {
-        last = packToken((*it)->clone());
-        return &last;
-      } else {
-        reset();
-        return 0;
-      }
-    }
-    void reset() { it = list->begin(); }
-
-    TokenBase* clone() const {
-      return new TupleIterator(*this);
-    }
-  };
-
- public:
-  Iterator* getIterator() {
-    return new TupleIterator(&tuple);
-  }
-
- public:
-  Tuple_t tuple;
-
- public:
-  Tuple() { this->type = TUPLE; }
-  Tuple(const TokenBase* a);
-  Tuple(const TokenBase* a, const TokenBase* b);
-  Tuple(const Tuple& t) : tuple(copyTuple(t.tuple)) { this->type = TUPLE; }
-  ~Tuple() { cleanTuple(&tuple); }
-
- public:
-  void push_back(const TokenBase* tb);
-  TokenBase* pop_front();
-  unsigned int size();
-
- private:
-  Tuple_t copyTuple(const Tuple_t& t);
-  void cleanTuple(Tuple_t* t);
-
- public:
-  Tuple& operator=(const Tuple& t);
-
-  virtual TokenBase* clone() const {
-    return new Tuple(static_cast<const Tuple&>(*this));
-  }
-};
-
 class TokenMap;
 typedef std::map<std::string, packToken> TokenMap_t;
 
@@ -200,23 +141,6 @@ class TokenList : public pack<TokenList_t>, public Iterable {
 
  public:
   TokenList() { this->type = LIST; }
-  TokenList(TokenBase* token) {
-    this->type = LIST;
-
-    if (!(token->type & IT)) {
-      throw std::invalid_argument("Invalid argument to build a list!");
-    }
-
-    Iterator* it = static_cast<Iterable*>(token)->getIterator();
-
-    packToken* next = it->next();
-    while (next) {
-      list().push_back(*next);
-      next = it->next();
-    }
-
-    delete it;
-  }
   virtual ~TokenList() {}
 
   packToken& operator[](size_t idx) {
@@ -231,6 +155,27 @@ class TokenList : public pack<TokenList_t>, public Iterable {
   // Implement the TokenBase abstract class
   TokenBase* clone() const {
     return new TokenList(*this);
+  }
+};
+
+class Tuple : public TokenList {
+ public:
+  Tuple() { this->type = TUPLE; }
+  Tuple(TokenBase* first) {
+    this->type = TUPLE;
+    list().push_back(packToken(first->clone()));
+  }
+
+  Tuple(TokenBase* first, TokenBase* second) {
+    this->type = TUPLE;
+    list().push_back(packToken(first->clone()));
+    list().push_back(packToken(second->clone()));
+  }
+
+ public:
+  // Implement the TokenBase abstract class
+  TokenBase* clone() const {
+    return new Tuple(*this);
   }
 };
 

--- a/objects.h
+++ b/objects.h
@@ -179,4 +179,34 @@ class Tuple : public TokenList {
   }
 };
 
+// This Special Tuple is to be used only as syntactic sugar, and
+// constructed only with the operator `:`, i.e.:
+// - passing key-word arguments: func(1, 2, optional_arg:10)
+// - slicing lists or strings: my_list[2:10:2] (not implemented)
+//
+// STuple means one of:
+// - Special Tuple, Syntactic Tuple or System Tuple
+//
+// I haven't decided yet. Suggestions accepted.
+class STuple : public Tuple {
+ public:
+  STuple() { this->type = STUPLE; }
+  STuple(TokenBase* first) {
+    this->type = STUPLE;
+    list().push_back(packToken(first->clone()));
+  }
+
+  STuple(TokenBase* first, TokenBase* second) {
+    this->type = STUPLE;
+    list().push_back(packToken(first->clone()));
+    list().push_back(packToken(second->clone()));
+  }
+
+ public:
+  // Implement the TokenBase abstract class
+  TokenBase* clone() const {
+    return new STuple(*this);
+  }
+};
+
 #endif  // OBJECTS_H_

--- a/objects.h
+++ b/objects.h
@@ -11,8 +11,15 @@
 // reference counting.
 #include "./pack.h"
 
+class Iterator;
+
+struct Iterable : public TokenBase {
+  virtual ~Iterable() {}
+  virtual Iterator* getIterator() = 0;
+};
+
 // Iterator super class.
-struct Iterator : public TokenBase {
+struct Iterator : public Iterable {
   Iterator() { this->type = IT; }
   virtual ~Iterator() {}
   // Return the next position of the iterator.
@@ -20,11 +27,8 @@ struct Iterator : public TokenBase {
   // and reset the iterator automatically.
   virtual packToken* next() = 0;
   virtual void reset() = 0;
-};
 
-struct Iterable : public TokenBase {
-  virtual ~Iterable() {}
-  virtual Iterator* getIterator() = 0;
+  Iterator* getIterator();
 };
 
 class Tuple : public Iterable {
@@ -203,12 +207,7 @@ class TokenList : public pack<TokenList_t>, public Iterable {
       throw std::invalid_argument("Invalid argument to build a list!");
     }
 
-    Iterator* it;
-    if (token->type == IT) {
-      it = static_cast<Iterator*>(token->clone());
-    } else {
-      it = static_cast<Iterable*>(token)->getIterator();
-    }
+    Iterator* it = static_cast<Iterable*>(token)->getIterator();
 
     packToken* next = it->next();
     while (next) {

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -85,7 +85,7 @@ bool packToken::asBool() const {
     case NONE:
       return false;
     case TUPLE:
-      return static_cast<Tuple*>(base)->tuple.size() != 0;
+      return static_cast<Tuple*>(base)->list().size() != 0;
     default:
       throw bad_cast("Token type can not be cast to boolean!");
   }
@@ -192,7 +192,7 @@ std::string packToken::str(const TokenBase* base) {
     case TUPLE:
       ss << "(";
       first = true;
-      for (const TokenBase* token : static_cast<const Tuple*>(base)->tuple) {
+      for (const TokenBase* token : static_cast<const Tuple*>(base)->list()) {
         if (!first) {
           ss << ", ";
         } else {

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -85,6 +85,7 @@ bool packToken::asBool() const {
     case NONE:
       return false;
     case TUPLE:
+    case STUPLE:
       return static_cast<Tuple*>(base)->list().size() != 0;
     default:
       throw bad_cast("Token type can not be cast to boolean!");
@@ -190,6 +191,7 @@ std::string packToken::str(const TokenBase* base) {
       if (name.size()) return "[Function: " + name + "]";
       return "[Function]";
     case TUPLE:
+    case STUPLE:
       ss << "(";
       first = true;
       for (const TokenBase* token : static_cast<const Tuple*>(base)->list()) {

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -229,6 +229,9 @@ std::string packToken::str(const TokenBase* base) {
       ss << " ]";
       return ss.str();
     default:
+      if (base->type & IT) {
+        return "[Iterator]";
+      }
       return "unknown_type";
   }
 }

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -28,7 +28,7 @@ OppMap_t calculator::buildOpPrecedence() {
   opp["=="] = 9; opp["!="] = 9;
   opp["&&"] = 13;
   opp["||"] = 14;
-  opp["="] = 15;
+  opp["="] = 15; opp[":"] = 15;
   opp[","] = 16;
   opp["("]  = 17; opp["["] = 17;
 
@@ -457,6 +457,16 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn, TokenMap vars) {
           evaluation.push(tuple);
         } else {
           evaluation.push(new Tuple(b_left, b_right));
+          delete b_left;
+          delete b_right;
+        }
+      } else if (!op.compare(":")) {
+        if (b_left->type == STUPLE) {
+          STuple* tuple = static_cast<STuple*>(b_left);
+          tuple->list().push_back(packToken(b_right));
+          evaluation.push(tuple);
+        } else {
+          evaluation.push(new STuple(b_left, b_right));
           delete b_left;
           delete b_right;
         }
@@ -924,6 +934,7 @@ void calculator::compile(const char* expr,
 
 packToken calculator::eval(TokenMap vars, bool keep_refs) const {
   TokenBase* value = calculate(this->RPN, vars);
+  packToken p = packToken(value->clone());
   if (keep_refs) {
     return packToken(value);
   } else {

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -453,8 +453,7 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn, TokenMap vars) {
       if (!op.compare(",")) {
         if (b_left->type == TUPLE) {
           Tuple* tuple = static_cast<Tuple*>(b_left);
-          tuple->push_back(b_right);
-          delete b_right;
+          tuple->list().push_back(packToken(b_right));
           evaluation.push(tuple);
         } else {
           evaluation.push(new Tuple(b_left, b_right));
@@ -641,7 +640,7 @@ TokenBase* calculator::calculate(TokenQueue_t _rpn, TokenMap vars) {
         delete b_right;
 
         std::string output;
-        for (const TokenBase* token : right.tuple) {
+        for (const TokenBase* token : right.list()) {
           // Find the next occurrence of "%s"
           while (*left && (*left != '%' || left[1] != 's')) {
             if (*left == '\\' && left[1] == '%') ++left;

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -118,7 +118,7 @@ class calculator {
 
  public:
   ~calculator();
-  calculator() {}
+  calculator() { this->RPN.push(new TokenNone()); }
   calculator(const calculator& calc);
   calculator(const char* expr, TokenMap vars = &TokenMap::empty,
              const char* delim = 0, const char** rest = 0,

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -17,11 +17,12 @@ enum tokType {
   INT = 0x9,   // == 0x8 + 0x1 => Integers are numbers.
 
   // Complex types:
-  IT = 0x20,     // Everything with the bit 0x20 set is an iterator.
-  TUPLE = 0x21,  // == 0x20 + 0x01 => Tuples are iterators.
-  LIST = 0x22,   // == 0x20 + 0x01 => Lists are iterators.
-  MAP = 0x60,    // == 0x20 + 0x40 => Maps are Iterators
-                 // Everything with the bit 0x40 set is a MAP.
+  IT = 0x20,      // Everything with the bit 0x20 set is an iterator.
+  LIST = 0x21,    // == 0x20 + 0x01 => Lists are iterators.
+  TUPLE = 0x22,   // == 0x20 + 0x01 => Tuples are iterators.
+  STUPLE = 0x23,  // == 0x20 + 0x02 => ArgTuples are iterators.
+  MAP = 0x60,     // == 0x20 + 0x40 => Maps are Iterators
+                  // Everything with the bit 0x40 set is a MAP.
   REF = 0x80
 };
 
@@ -132,7 +133,7 @@ class calculator {
   static std::string str(TokenQueue_t rpn);
 
   // Operators:
-  calculator& operator = (const calculator& calc);
+  calculator& operator=(const calculator& calc);
 };
 
 #endif  // SHUNTING_YARD_H_

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -52,7 +52,6 @@ struct TokenNone : public TokenBase {
 class packToken;
 typedef std::queue<TokenBase*> TokenQueue_t;
 typedef std::map<std::string, int> OppMap_t;
-typedef std::list<TokenBase*> Tuple_t;
 
 class TokenMap;
 class TokenList;

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -153,6 +153,25 @@ TEST_CASE("Prototypical inheritance tests") {
   REQUIRE(calculator::calculate("grand_child.a", vars).asDouble() == 12);
 }
 
+TEST_CASE("Map usage expressions", "[map]") {
+  TokenMap vars;
+  vars["my_map"] = TokenMap();
+  REQUIRE_NOTHROW(calculator::calculate("my_map['a'] = 1", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_map['b'] = 2", vars));
+  REQUIRE_NOTHROW(calculator::calculate("my_map['c'] = 3", vars));
+
+  REQUIRE(vars["my_map"].str() == "{ \"a\": 1, \"b\": 2, \"c\": 3 }");
+  REQUIRE(calculator::calculate("my_map.len()", vars).asInt() == 3);
+
+  REQUIRE_NOTHROW(calculator::calculate("my_map.pop('b')", vars));
+
+  REQUIRE(vars["my_map"].str() == "{ \"a\": 1, \"c\": 3 }");
+  REQUIRE(calculator::calculate("my_map.len()", vars).asDouble() == 2);
+
+  REQUIRE_NOTHROW(calculator::calculate("default = my_map.pop('b', 3)", vars));
+  REQUIRE(vars["default"].asInt() == 3);
+}
+
 TEST_CASE("List usage expressions", "[list]") {
   TokenMap vars;
   vars["my_list"] = TokenList();
@@ -162,7 +181,7 @@ TEST_CASE("List usage expressions", "[list]") {
   REQUIRE_NOTHROW(calculator::calculate("my_list.push(3)", vars));
 
   REQUIRE(vars["my_list"].str() == "[ 1, 2, 3 ]");
-  REQUIRE(calculator::calculate("my_list.len()", vars).asDouble() == 3);
+  REQUIRE(calculator::calculate("my_list.len()", vars).asInt() == 3);
 
   REQUIRE_NOTHROW(calculator::calculate("my_list.pop(1)", vars));
 

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -153,25 +153,6 @@ TEST_CASE("Prototypical inheritance tests") {
   REQUIRE(calculator::calculate("grand_child.a", vars).asDouble() == 12);
 }
 
-TEST_CASE("Test usage of functions `extend` function") {
-  GlobalScope vars;
-
-  REQUIRE_NOTHROW(calculator::calculate("a = map()", vars));
-  REQUIRE_NOTHROW(calculator::calculate("b = extend(a)", vars));
-  REQUIRE_NOTHROW(calculator::calculate("a.a = 10", vars));
-  REQUIRE(calculator::calculate("b.a", vars).asDouble() == 10);
-  REQUIRE_NOTHROW(calculator::calculate("b.a = 20", vars));
-  REQUIRE(calculator::calculate("a.a", vars).asDouble() == 10);
-  REQUIRE(calculator::calculate("b.a", vars).asDouble() == 20);
-
-  REQUIRE_NOTHROW(calculator::calculate("c = extend(b)", vars));
-  REQUIRE(calculator::calculate("a.instanceof(b)", vars).asBool() == false);
-  REQUIRE(calculator::calculate("a.instanceof(c)", vars).asBool() == false);
-  REQUIRE(calculator::calculate("b.instanceof(a)", vars).asBool() == true);
-  REQUIRE(calculator::calculate("c.instanceof(a)", vars).asBool() == true);
-  REQUIRE(calculator::calculate("c.instanceof(b)", vars).asBool() == true);
-}
-
 TEST_CASE("List usage expressions", "[list]") {
   TokenMap vars;
   vars["my_list"] = TokenList();
@@ -354,6 +335,25 @@ TEST_CASE("Function usage expressions") {
   vars["base"] = 3;
   REQUIRE(c.eval().asDouble() == 4);
   REQUIRE(c.eval(vars).asDouble() == 9);
+}
+
+TEST_CASE("Built-in extend() function") {
+  GlobalScope vars;
+
+  REQUIRE_NOTHROW(calculator::calculate("a = map()", vars));
+  REQUIRE_NOTHROW(calculator::calculate("b = extend(a)", vars));
+  REQUIRE_NOTHROW(calculator::calculate("a.a = 10", vars));
+  REQUIRE(calculator::calculate("b.a", vars).asDouble() == 10);
+  REQUIRE_NOTHROW(calculator::calculate("b.a = 20", vars));
+  REQUIRE(calculator::calculate("a.a", vars).asDouble() == 10);
+  REQUIRE(calculator::calculate("b.a", vars).asDouble() == 20);
+
+  REQUIRE_NOTHROW(calculator::calculate("c = extend(b)", vars));
+  REQUIRE(calculator::calculate("a.instanceof(b)", vars).asBool() == false);
+  REQUIRE(calculator::calculate("a.instanceof(c)", vars).asBool() == false);
+  REQUIRE(calculator::calculate("b.instanceof(a)", vars).asBool() == true);
+  REQUIRE(calculator::calculate("c.instanceof(a)", vars).asBool() == true);
+  REQUIRE(calculator::calculate("c.instanceof(b)", vars).asBool() == true);
 }
 
 TEST_CASE("Built-in str() function") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -519,6 +519,9 @@ TEST_CASE("Exception management") {
   REQUIRE_THROWS(calculator(""));
   REQUIRE_THROWS(calculator("      "));
 
+  // Uninitialized calculators should eval to None:
+  REQUIRE(calculator().eval().str() == "None");
+
   REQUIRE_THROWS(ecalc.eval());
   REQUIRE_NOTHROW(ecalc.eval(emap));
 

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -172,7 +172,7 @@ TEST_CASE("Test usage of functions `extend` function") {
   REQUIRE(calculator::calculate("c.instanceof(b)", vars).asBool() == true);
 }
 
-TEST_CASE("List usage expressions") {
+TEST_CASE("List usage expressions", "[list]") {
   TokenMap vars;
   vars["my_list"] = TokenList();
 
@@ -211,6 +211,28 @@ TEST_CASE("List usage expressions") {
   // List index out of range:
   REQUIRE_THROWS(calculator::calculate("concat[10]", vars));
   REQUIRE_THROWS(calculator::calculate("concat[-10]", vars));
+}
+
+TEST_CASE("Tuple usage expressions", "[tuple]") {
+  TokenMap vars;
+  calculator c;
+
+  REQUIRE_NOTHROW(c.compile("'key':'value'"));
+  STuple* t0 = static_cast<STuple*>(c.eval()->clone());
+  REQUIRE(t0->type == STUPLE);
+  REQUIRE(t0->list().size() == 2);
+  delete t0;
+
+  REQUIRE_NOTHROW(c.compile("1, 'key':'value', 3"));
+  Tuple* t1 = static_cast<Tuple*>(c.eval()->clone());
+  REQUIRE(t1->type == TUPLE);
+  REQUIRE(t1->list().size() == 3);
+
+  STuple* t2 = static_cast<STuple*>(t1->list()[1]->clone());
+  REQUIRE(t2->type == STUPLE);
+  REQUIRE(t2->list().size() == 2);
+  delete t1;
+  delete t2;
 }
 
 TEST_CASE("List and map constructors usage") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -376,6 +376,17 @@ TEST_CASE("Multiple argument functions") {
   REQUIRE(vars["total"].asDouble() == 10);
 }
 
+TEST_CASE("Passing keyword arguments to functions") {
+  GlobalScope vars;
+  REQUIRE_NOTHROW(calculator::calculate("my_map = map('a':1,'b':2)", vars));
+
+  TokenMap map;
+  REQUIRE_NOTHROW(map = vars["my_map"].asMap());
+
+  REQUIRE(map["a"].asInt() == 1);
+  REQUIRE(map["b"].asInt() == 2);
+}
+
 TEST_CASE("Default functions") {
   REQUIRE(calculator::calculate("type(None)").asString() == "none");
   REQUIRE(calculator::calculate("type(10.0)").asString() == "float");

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -315,8 +315,6 @@ TEST_CASE("Function usage expressions") {
 
   REQUIRE(calculator::calculate(" float('0.1') ").asDouble() == 0.1);
   REQUIRE(calculator::calculate("float(10)").asDouble() == 10);
-  REQUIRE(calculator::calculate(" str(10) ").asString() == "10");
-  REQUIRE(calculator::calculate(" str('texto') ").asString() == "texto");
 
   vars["a"] = 0;
   REQUIRE(calculator::calculate(" eval('a = 3') ", vars).asDouble() == 3);
@@ -334,6 +332,20 @@ TEST_CASE("Function usage expressions") {
   vars["base"] = 3;
   REQUIRE(c.eval().asDouble() == 4);
   REQUIRE(c.eval(vars).asDouble() == 9);
+}
+
+TEST_CASE("Built-in str() function") {
+  REQUIRE(calculator::calculate(" str(None) ").asString() == "None");
+  REQUIRE(calculator::calculate(" str(10) ").asString() == "10");
+  REQUIRE(calculator::calculate(" str(10.1) ").asString() == "10.1");
+  REQUIRE(calculator::calculate(" str('texto') ").asString() == "texto");
+  REQUIRE(calculator::calculate(" str(list(1,2,3)) ").asString() == "[ 1, 2, 3 ]");
+  REQUIRE(calculator::calculate(" str(map()) ").asString() == "{}");
+  REQUIRE(calculator::calculate(" str(map) ").asString() == "[Function: map]");
+
+  vars["iterator"] = packToken(new TokenList());
+  vars["iterator"]->type = IT;
+  REQUIRE(calculator::calculate("str(iterator)", vars).asString() == "[Iterator]");
 }
 
 TEST_CASE("Multiple argument functions") {


### PR DESCRIPTION
The major changes are these 3:

- Tuples now inherit from TokenList and are managed by the same garbage collector.
- Map now have the built-in functions: pop() and len()
- The map constructor now accepts Special Tuples, e.g.:

```javascript
my_map = map('val1': 10, 'val2': 20, 'val3': 30)
print(my_map) // { "val1": 10, "val2": 20, "val3": 30 }
```

Please note that these tuples will work as key-value arguments for any function. A lot like it does in Python with the operator `=`. So if you want to access the last argument of a function with many arguments you just need to write: `func('arg_name': 'arg_value')`.

Also if the key-value pair does not refer to an existing function argument it will be added to a built-in dictionary called: `kwargs` available inside the functions scope (much like the already implemented `args` that contains a list of extra arguments).

Besides that, there is also some minor refactoring and bug-fixing.

Next tasks:
- Update README.md to contain all the new features.
- Decouple the addition of new operations from the calculator class code.
- Add built-in definition of dictionaries and lists with JSON syntax.
- Add support for adhoc sub-parsers for reserved words, e.g. `new ...` or `function (...) {...}` etc.