### PR TITLE
Expose an API to define the parsing of reserved words

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -1,7 +1,3 @@
-
-#ifndef OPERATIONS_H_
-#define OPERATIONS_H_
-
 #include <math.h>
 #include <sstream>
 
@@ -446,4 +442,32 @@ struct Startup {
 
 }  // namespace builtin_operations
 
-#endif  // OPERATIONS_H_
+namespace builtin_reservedWords {
+
+// Literal Tokens: True, False and None:
+packToken trueToken = packToken(1);
+packToken falseToken = packToken(0);
+packToken noneToken = TokenNone();
+
+TokenBase* True(const char* expr, const char** rest, rpnBuilder* data) {
+  return trueToken->clone();
+}
+
+TokenBase* False(const char* expr, const char** rest, rpnBuilder* data) {
+  return falseToken->clone();
+}
+
+TokenBase* None(const char* expr, const char** rest, rpnBuilder* data) {
+  return noneToken->clone();
+}
+
+struct Startup {
+  Startup() {
+    rWordMap_t& rwMap = calculator::default_rWordMap();
+    rwMap["True"] = &True;
+    rwMap["False"] = &False;
+    rwMap["None"] = &None;
+  }
+} Startup;
+
+}  // namespace builtin_reservedWords


### PR DESCRIPTION
Now the user has access to the `calculator::default_rWordMap()` map.

this map links reserved words, i.e. std::strings with functions
specialized in parsing them. These function can be defined
by the user.

Now it is possible for example to declare a function inside an expression.

Currently it is only used for 3 reserved words:

- True
- False
- None

This is a good thing since it solves issue #32 of having
these reserved word values hard-coded.